### PR TITLE
Add initial database schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,18 +5,21 @@ go 1.24.3
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/getkin/kin-openapi v0.132.0
+	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/oapi-codegen/echo-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.1.2
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/google/uuid v1.5.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
@@ -28,6 +31,7 @@ require (
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/speakeasy-api/jsonpath v0.6.0 // indirect
 	github.com/speakeasy-api/openapi-overlay v0.10.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
@@ -37,8 +39,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
-github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -46,6 +48,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/internal/domain/model/oss_component.go
+++ b/internal/domain/model/oss_component.go
@@ -1,0 +1,27 @@
+package model
+
+import "time"
+
+// OssComponent represents OSS component entity.
+type OssComponent struct {
+	ID               string
+	Name             string
+	NormalizedName   string
+	HomepageURL      *string
+	RepositoryURL    *string
+	Description      *string
+	PrimaryLanguage  *string
+	Layers           []string
+	DefaultUsageRole *string
+	Deprecated       bool
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	Tags             []Tag
+}
+
+// Tag represents a classification tag.
+type Tag struct {
+	ID        string
+	Name      string
+	CreatedAt *time.Time
+}

--- a/internal/domain/repository/oss_component_repository.go
+++ b/internal/domain/repository/oss_component_repository.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+)
+
+// OssComponentFilter filters search results.
+type OssComponentFilter struct {
+	Name        string   // partial match on normalized_name
+	Layers      []string // OR condition
+	Tag         string   // exact match tag name
+	InScopeOnly bool
+	Page        int
+	Size        int
+}
+
+// OssComponentRepository defines DB operations for OssComponent.
+type OssComponentRepository interface {
+	Search(ctx context.Context, f OssComponentFilter) ([]model.OssComponent, int, error)
+	Create(ctx context.Context, c *model.OssComponent) error
+}

--- a/internal/infra/db/db.go
+++ b/internal/infra/db/db.go
@@ -1,0 +1,26 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+)
+
+// DB wraps sql.DB and provides transaction management.
+type DB struct {
+	*sql.DB
+}
+
+// WithinTx executes fn within a transaction.
+func (d *DB) WithinTx(ctx context.Context, fn func(ctx context.Context, tx *sql.Tx) error) error {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if err := fn(ctx, tx); err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil {
+			return rbErr
+		}
+		return err
+	}
+	return tx.Commit()
+}

--- a/internal/infra/repository/oss_component_repository.go
+++ b/internal/infra/repository/oss_component_repository.go
@@ -1,0 +1,75 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+// OssComponentRepository implements domrepo.OssComponentRepository.
+type OssComponentRepository struct {
+	DB *sql.DB
+}
+
+// Search returns oss components matching filter.
+func (r *OssComponentRepository) Search(ctx context.Context, f domrepo.OssComponentFilter) ([]model.OssComponent, int, error) {
+	var args []any
+	var wheres []string
+	if f.Name != "" {
+		args = append(args, "%"+strings.ToLower(f.Name)+"%")
+		wheres = append(wheres, "normalized_name LIKE ?")
+	}
+	if len(f.Layers) > 0 {
+		placeholders := make([]string, len(f.Layers))
+		for i, l := range f.Layers {
+			placeholders[i] = "?"
+			args = append(args, l)
+		}
+		wheres = append(wheres, fmt.Sprintf("EXISTS (SELECT 1 FROM oss_component_layers l WHERE l.oss_id = oc.id AND l.layer IN (%s))", strings.Join(placeholders, ",")))
+	}
+	if f.Tag != "" {
+		wheres = append(wheres, "EXISTS (SELECT 1 FROM oss_component_tags t JOIN tags tg ON t.tag_id = tg.id WHERE t.oss_id = oc.id AND tg.name = ?)")
+		args = append(args, f.Tag)
+	}
+	whereSQL := ""
+	if len(wheres) > 0 {
+		whereSQL = "WHERE " + strings.Join(wheres, " AND ")
+	}
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM oss_components oc %s", whereSQL)
+	row := r.DB.QueryRowContext(ctx, countQuery, args...)
+	var total int
+	if err := row.Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	offset := (f.Page - 1) * f.Size
+	query := fmt.Sprintf(`SELECT oc.id, oc.name, oc.normalized_name, oc.homepage_url, oc.repository_url, oc.description, oc.primary_language, oc.default_usage_role, oc.deprecated, oc.created_at, oc.updated_at FROM oss_components oc %s ORDER BY oc.created_at DESC LIMIT ? OFFSET ?`, whereSQL)
+	argsWithLimit := append(args, f.Size, offset)
+
+	rows, err := r.DB.QueryContext(ctx, query, argsWithLimit...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var comps []model.OssComponent
+	for rows.Next() {
+		var c model.OssComponent
+		if err := rows.Scan(&c.ID, &c.Name, &c.NormalizedName, &c.HomepageURL, &c.RepositoryURL, &c.Description, &c.PrimaryLanguage, &c.DefaultUsageRole, &c.Deprecated, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, 0, err
+		}
+		comps = append(comps, c)
+	}
+	return comps, total, rows.Err()
+}
+
+// Create inserts a new oss component.
+func (r *OssComponentRepository) Create(ctx context.Context, c *model.OssComponent) error {
+	query := `INSERT INTO oss_components (id, name, normalized_name, homepage_url, repository_url, description, primary_language, default_usage_role, deprecated, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err := r.DB.ExecContext(ctx, query, c.ID, c.Name, c.NormalizedName, c.HomepageURL, c.RepositoryURL, c.Description, c.PrimaryLanguage, c.DefaultUsageRole, c.Deprecated, c.CreatedAt, c.UpdatedAt)
+	return err
+}

--- a/internal/infra/repository/oss_component_repository_test.go
+++ b/internal/infra/repository/oss_component_repository_test.go
@@ -1,0 +1,62 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+func TestOssComponentRepository_Search(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssComponentRepository{DB: db}
+
+	f := domrepo.OssComponentFilter{Name: "redis", Page: 1, Size: 10}
+
+	countQuery := regexp.QuoteMeta("SELECT COUNT(*) FROM oss_components oc WHERE normalized_name LIKE ?")
+	mock.ExpectQuery(countQuery).WithArgs("%redis%").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	listQuery := regexp.QuoteMeta("SELECT oc.id, oc.name, oc.normalized_name, oc.homepage_url, oc.repository_url, oc.description, oc.primary_language, oc.default_usage_role, oc.deprecated, oc.created_at, oc.updated_at FROM oss_components oc WHERE normalized_name LIKE ? ORDER BY oc.created_at DESC LIMIT ? OFFSET ?")
+	now := time.Now()
+	mock.ExpectQuery(listQuery).WithArgs("%redis%", 10, 0).WillReturnRows(sqlmock.NewRows([]string{"id", "name", "normalized_name", "homepage_url", "repository_url", "description", "primary_language", "default_usage_role", "deprecated", "created_at", "updated_at"}).AddRow(uuid.NewString(), "Redis", "redis", nil, nil, nil, nil, nil, false, now, now))
+
+	res, total, err := repo.Search(context.Background(), f)
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, res, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOssComponentRepository_Create(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssComponentRepository{DB: db}
+
+	c := &model.OssComponent{
+		ID:             uuid.NewString(),
+		Name:           "Redis",
+		NormalizedName: "redis",
+		Deprecated:     false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	query := regexp.QuoteMeta("INSERT INTO oss_components (id, name, normalized_name, homepage_url, repository_url, description, primary_language, default_usage_role, deprecated, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+	mock.ExpectExec(query).WithArgs(c.ID, c.Name, c.NormalizedName, c.HomepageURL, c.RepositoryURL, c.Description, c.PrimaryLanguage, c.DefaultUsageRole, c.Deprecated, c.CreatedAt, c.UpdatedAt).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Create(context.Background(), c)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/migrations/0001_create_tables.down.sql
+++ b/migrations/0001_create_tables.down.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS audit_logs;
+DROP TABLE IF EXISTS scope_policies;
+DROP TABLE IF EXISTS project_usages;
+DROP TABLE IF EXISTS projects;
+DROP TABLE IF EXISTS oss_versions;
+DROP TABLE IF EXISTS oss_component_layers;
+DROP TABLE IF EXISTS oss_component_tags;
+DROP TABLE IF EXISTS oss_components;
+DROP TABLE IF EXISTS tags;

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -1,0 +1,103 @@
+CREATE TABLE tags (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE oss_components (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    normalized_name TEXT NOT NULL UNIQUE,
+    homepage_url TEXT,
+    repository_url TEXT,
+    description TEXT,
+    primary_language TEXT,
+    default_usage_role TEXT,
+    deprecated BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE oss_component_tags (
+    oss_id UUID NOT NULL REFERENCES oss_components(id) ON DELETE CASCADE,
+    tag_id UUID NOT NULL REFERENCES tags(id),
+    PRIMARY KEY (oss_id, tag_id)
+);
+
+CREATE TABLE oss_component_layers (
+    oss_id UUID NOT NULL REFERENCES oss_components(id) ON DELETE CASCADE,
+    layer TEXT NOT NULL,
+    PRIMARY KEY (oss_id, layer)
+);
+
+CREATE TABLE oss_versions (
+    id UUID PRIMARY KEY,
+    oss_id UUID NOT NULL REFERENCES oss_components(id) ON DELETE CASCADE,
+    version TEXT NOT NULL,
+    release_date DATE,
+    license_expression_raw TEXT,
+    license_concluded TEXT,
+    purl TEXT,
+    cpe_list TEXT[],
+    hash_sha256 TEXT,
+    modified BOOLEAN NOT NULL DEFAULT FALSE,
+    modification_description TEXT,
+    review_status TEXT NOT NULL,
+    last_reviewed_at TIMESTAMPTZ,
+    scope_status TEXT NOT NULL,
+    supplier_type TEXT,
+    fork_origin_url TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_oss_versions_oss_id ON oss_versions (oss_id);
+
+CREATE TABLE projects (
+    id UUID PRIMARY KEY,
+    project_code TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    department TEXT,
+    manager TEXT,
+    delivery_date DATE,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE project_usages (
+    id UUID PRIMARY KEY,
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    oss_id UUID NOT NULL REFERENCES oss_components(id) ON DELETE CASCADE,
+    oss_version_id UUID NOT NULL REFERENCES oss_versions(id) ON DELETE CASCADE,
+    usage_role TEXT NOT NULL,
+    scope_status TEXT NOT NULL,
+    inclusion_note TEXT,
+    direct_dependency BOOLEAN NOT NULL DEFAULT TRUE,
+    added_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    evaluated_at TIMESTAMPTZ,
+    evaluated_by TEXT
+);
+
+CREATE INDEX idx_project_usages_project_id ON project_usages (project_id);
+CREATE INDEX idx_project_usages_oss_version_id ON project_usages (oss_version_id);
+
+CREATE TABLE scope_policies (
+    id UUID PRIMARY KEY,
+    runtime_required_default_in_scope BOOLEAN NOT NULL,
+    server_env_included BOOLEAN NOT NULL,
+    auto_mark_forks_in_scope BOOLEAN NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    updated_by TEXT NOT NULL
+);
+
+CREATE TABLE audit_logs (
+    id UUID PRIMARY KEY,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    summary TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_audit_logs_entity ON audit_logs (entity_type, entity_id);


### PR DESCRIPTION
## Summary
- introduce migrations directory with PostgreSQL-compatible schema
- create tables for OSS components, versions, projects, usages, tags and audits

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ce035fe948320b17f915d2845f8e3