### PR TITLE
Implement OssVersion repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcX
 github.com/labstack/echo/v4 v4.13.4/go.mod h1:g63b33BZ5vZzcIUF8AtRH40DrTlXnx4UMC8rBdndmjQ=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/internal/domain/model/oss_version.go
+++ b/internal/domain/model/oss_version.go
@@ -1,0 +1,25 @@
+package model
+
+import "time"
+
+// OssVersion represents a version of an OSS component.
+type OssVersion struct {
+	ID                      string
+	OssID                   string
+	Version                 string
+	ReleaseDate             *time.Time
+	LicenseExpressionRaw    *string
+	LicenseConcluded        *string
+	Purl                    *string
+	CpeList                 []string
+	HashSha256              *string
+	Modified                bool
+	ModificationDescription *string
+	ReviewStatus            string
+	LastReviewedAt          *time.Time
+	ScopeStatus             string
+	SupplierType            *string
+	ForkOriginURL           *string
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+}

--- a/internal/domain/repository/oss_version_repository.go
+++ b/internal/domain/repository/oss_version_repository.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+)
+
+// OssVersionFilter filters search results.
+type OssVersionFilter struct {
+	OssID        string
+	ReviewStatus string
+	ScopeStatus  string
+	Page         int
+	Size         int
+}
+
+// OssVersionRepository defines DB operations for OssVersion.
+type OssVersionRepository interface {
+	Search(ctx context.Context, f OssVersionFilter) ([]model.OssVersion, int, error)
+	Get(ctx context.Context, id string) (*model.OssVersion, error)
+	Create(ctx context.Context, v *model.OssVersion) error
+	Update(ctx context.Context, v *model.OssVersion) error
+	Delete(ctx context.Context, id string) error
+}

--- a/internal/infra/repository/oss_version_repository.go
+++ b/internal/infra/repository/oss_version_repository.go
@@ -1,0 +1,162 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/lib/pq"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+// OssVersionRepository implements domrepo.OssVersionRepository.
+type OssVersionRepository struct {
+	DB *sql.DB
+}
+
+var _ domrepo.OssVersionRepository = (*OssVersionRepository)(nil)
+
+// Search returns versions for an OSS component.
+func (r *OssVersionRepository) Search(ctx context.Context, f domrepo.OssVersionFilter) ([]model.OssVersion, int, error) {
+	var args []any
+	wheres := []string{"oss_id = ?"}
+	args = append(args, f.OssID)
+	if f.ReviewStatus != "" {
+		wheres = append(wheres, "review_status = ?")
+		args = append(args, f.ReviewStatus)
+	}
+	if f.ScopeStatus != "" {
+		wheres = append(wheres, "scope_status = ?")
+		args = append(args, f.ScopeStatus)
+	}
+	whereSQL := "WHERE " + strings.Join(wheres, " AND ")
+
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM oss_versions %s", whereSQL)
+	row := r.DB.QueryRowContext(ctx, countQuery, args...)
+	var total int
+	if err := row.Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	offset := (f.Page - 1) * f.Size
+	listQuery := fmt.Sprintf(`SELECT id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at FROM oss_versions %s ORDER BY created_at DESC LIMIT ? OFFSET ?`, whereSQL)
+	argsWithLimit := append(args, f.Size, offset)
+	rows, err := r.DB.QueryContext(ctx, listQuery, argsWithLimit...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var versions []model.OssVersion
+	for rows.Next() {
+		var v model.OssVersion
+		var releaseDate sql.NullTime
+		var licenseRaw, licenseConc, purl, hash sql.NullString
+		var modDesc, supplier, fork sql.NullString
+		var lastReviewed sql.NullTime
+		var cpeList pq.StringArray
+		if err := rows.Scan(&v.ID, &v.OssID, &v.Version, &releaseDate, &licenseRaw, &licenseConc, &purl, &cpeList, &hash, &v.Modified, &modDesc, &v.ReviewStatus, &lastReviewed, &v.ScopeStatus, &supplier, &fork, &v.CreatedAt, &v.UpdatedAt); err != nil {
+			return nil, 0, err
+		}
+		if releaseDate.Valid {
+			v.ReleaseDate = &releaseDate.Time
+		}
+		if licenseRaw.Valid {
+			v.LicenseExpressionRaw = &licenseRaw.String
+		}
+		if licenseConc.Valid {
+			v.LicenseConcluded = &licenseConc.String
+		}
+		if purl.Valid {
+			v.Purl = &purl.String
+		}
+		v.CpeList = []string(cpeList)
+		if hash.Valid {
+			v.HashSha256 = &hash.String
+		}
+		if modDesc.Valid {
+			v.ModificationDescription = &modDesc.String
+		}
+		if lastReviewed.Valid {
+			v.LastReviewedAt = &lastReviewed.Time
+		}
+		if supplier.Valid {
+			v.SupplierType = &supplier.String
+		}
+		if fork.Valid {
+			v.ForkOriginURL = &fork.String
+		}
+		versions = append(versions, v)
+	}
+	return versions, total, rows.Err()
+}
+
+// Get returns a version by ID.
+func (r *OssVersionRepository) Get(ctx context.Context, id string) (*model.OssVersion, error) {
+	row := r.DB.QueryRowContext(ctx, `SELECT id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at FROM oss_versions WHERE id = ?`, id)
+	var v model.OssVersion
+	var releaseDate sql.NullTime
+	var licenseRaw, licenseConc, purl, hash sql.NullString
+	var modDesc, supplier, fork sql.NullString
+	var lastReviewed sql.NullTime
+	var cpeList pq.StringArray
+	if err := row.Scan(&v.ID, &v.OssID, &v.Version, &releaseDate, &licenseRaw, &licenseConc, &purl, &cpeList, &hash, &v.Modified, &modDesc, &v.ReviewStatus, &lastReviewed, &v.ScopeStatus, &supplier, &fork, &v.CreatedAt, &v.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if releaseDate.Valid {
+		v.ReleaseDate = &releaseDate.Time
+	}
+	if licenseRaw.Valid {
+		v.LicenseExpressionRaw = &licenseRaw.String
+	}
+	if licenseConc.Valid {
+		v.LicenseConcluded = &licenseConc.String
+	}
+	if purl.Valid {
+		v.Purl = &purl.String
+	}
+	v.CpeList = []string(cpeList)
+	if hash.Valid {
+		v.HashSha256 = &hash.String
+	}
+	if modDesc.Valid {
+		v.ModificationDescription = &modDesc.String
+	}
+	if lastReviewed.Valid {
+		v.LastReviewedAt = &lastReviewed.Time
+	}
+	if supplier.Valid {
+		v.SupplierType = &supplier.String
+	}
+	if fork.Valid {
+		v.ForkOriginURL = &fork.String
+	}
+	return &v, nil
+}
+
+// Create inserts a new version.
+func (r *OssVersionRepository) Create(ctx context.Context, v *model.OssVersion) error {
+	_, err := r.DB.ExecContext(ctx,
+		`INSERT INTO oss_versions (id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		v.ID, v.OssID, v.Version, v.ReleaseDate, v.LicenseExpressionRaw, v.LicenseConcluded, v.Purl, pq.Array(v.CpeList), v.HashSha256, v.Modified, v.ModificationDescription, v.ReviewStatus, v.LastReviewedAt, v.ScopeStatus, v.SupplierType, v.ForkOriginURL, v.CreatedAt, v.UpdatedAt,
+	)
+	return err
+}
+
+// Update updates an existing version.
+func (r *OssVersionRepository) Update(ctx context.Context, v *model.OssVersion) error {
+	_, err := r.DB.ExecContext(ctx,
+		`UPDATE oss_versions SET release_date = ?, license_expression_raw = ?, license_concluded = ?, purl = ?, cpe_list = ?, hash_sha256 = ?, modified = ?, modification_description = ?, review_status = ?, last_reviewed_at = ?, scope_status = ?, supplier_type = ?, fork_origin_url = ?, updated_at = ? WHERE id = ?`,
+		v.ReleaseDate, v.LicenseExpressionRaw, v.LicenseConcluded, v.Purl, pq.Array(v.CpeList), v.HashSha256, v.Modified, v.ModificationDescription, v.ReviewStatus, v.LastReviewedAt, v.ScopeStatus, v.SupplierType, v.ForkOriginURL, v.UpdatedAt, v.ID,
+	)
+	return err
+}
+
+// Delete removes a version by ID.
+func (r *OssVersionRepository) Delete(ctx context.Context, id string) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM oss_versions WHERE id = ?`, id)
+	return err
+}

--- a/internal/infra/repository/oss_version_repository_test.go
+++ b/internal/infra/repository/oss_version_repository_test.go
@@ -1,0 +1,112 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+func TestOssVersionRepository_Search(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssVersionRepository{DB: db}
+
+	f := domrepo.OssVersionFilter{OssID: uuid.NewString(), Page: 1, Size: 10}
+
+	countQuery := regexp.QuoteMeta("SELECT COUNT(*) FROM oss_versions WHERE oss_id = ?")
+	mock.ExpectQuery(countQuery).WithArgs(f.OssID).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	listQuery := regexp.QuoteMeta("SELECT id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at FROM oss_versions WHERE oss_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?")
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{"id", "oss_id", "version", "release_date", "license_expression_raw", "license_concluded", "purl", "cpe_list", "hash_sha256", "modified", "modification_description", "review_status", "last_reviewed_at", "scope_status", "supplier_type", "fork_origin_url", "created_at", "updated_at"}).
+		AddRow(uuid.NewString(), f.OssID, "1.0.0", now, nil, nil, nil, pq.StringArray{"cpe:/a"}, nil, false, nil, "draft", nil, "IN_SCOPE", nil, nil, now, now)
+	mock.ExpectQuery(listQuery).WithArgs(f.OssID, 10, 0).WillReturnRows(rows)
+
+	res, total, err := repo.Search(context.Background(), f)
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, res, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOssVersionRepository_Create(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssVersionRepository{DB: db}
+
+	v := &model.OssVersion{
+		ID:           uuid.NewString(),
+		OssID:        uuid.NewString(),
+		Version:      "1.0.0",
+		Modified:     false,
+		ReviewStatus: "draft",
+		ScopeStatus:  "IN_SCOPE",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	query := regexp.QuoteMeta("INSERT INTO oss_versions (id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+	mock.ExpectExec(query).
+		WithArgs(v.ID, v.OssID, v.Version, v.ReleaseDate, v.LicenseExpressionRaw, v.LicenseConcluded, v.Purl, sqlmock.AnyArg(), v.HashSha256, v.Modified, v.ModificationDescription, v.ReviewStatus, v.LastReviewedAt, v.ScopeStatus, v.SupplierType, v.ForkOriginURL, v.CreatedAt, v.UpdatedAt).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Create(context.Background(), v)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOssVersionRepository_Update(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssVersionRepository{DB: db}
+
+	v := &model.OssVersion{
+		ID:           uuid.NewString(),
+		ReleaseDate:  func() *time.Time { t := time.Now(); return &t }(),
+		Modified:     true,
+		ReviewStatus: "verified",
+		ScopeStatus:  "IN_SCOPE",
+		UpdatedAt:    time.Now(),
+	}
+
+	query := regexp.QuoteMeta("UPDATE oss_versions SET release_date = ?, license_expression_raw = ?, license_concluded = ?, purl = ?, cpe_list = ?, hash_sha256 = ?, modified = ?, modification_description = ?, review_status = ?, last_reviewed_at = ?, scope_status = ?, supplier_type = ?, fork_origin_url = ?, updated_at = ? WHERE id = ?")
+	mock.ExpectExec(query).
+		WithArgs(v.ReleaseDate, v.LicenseExpressionRaw, v.LicenseConcluded, v.Purl, sqlmock.AnyArg(), v.HashSha256, v.Modified, v.ModificationDescription, v.ReviewStatus, v.LastReviewedAt, v.ScopeStatus, v.SupplierType, v.ForkOriginURL, v.UpdatedAt, v.ID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Update(context.Background(), v)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOssVersionRepository_Delete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssVersionRepository{DB: db}
+
+	id := uuid.NewString()
+
+	query := regexp.QuoteMeta("DELETE FROM oss_versions WHERE id = ?")
+	mock.ExpectExec(query).WithArgs(id).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Delete(context.Background(), id)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
- implement domain model for `OssVersion`
- add repository interface and concrete implementation for `oss_versions`
- provide tests using `go-sqlmock`
- add `lib/pq` dependency for array handling

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687ce99015a48320b4a92998427ea9b8