### PR TITLE
Implement project repository with sqlmock tests

### DIFF
--- a/internal/domain/model/project.go
+++ b/internal/domain/model/project.go
@@ -1,0 +1,17 @@
+package model
+
+import "time"
+
+// Project represents a delivery unit project.
+type Project struct {
+	ID            string
+	ProjectCode   string
+	Name          string
+	Department    *string
+	Manager       *string
+	DeliveryDate  *time.Time
+	Description   *string
+	OssUsageCount int
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}

--- a/internal/domain/repository/project_repository.go
+++ b/internal/domain/repository/project_repository.go
@@ -1,0 +1,24 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+)
+
+// ProjectFilter filters project listing.
+type ProjectFilter struct {
+	Code string
+	Name string
+	Page int
+	Size int
+}
+
+// ProjectRepository defines DB operations for Project.
+type ProjectRepository interface {
+	Search(ctx context.Context, f ProjectFilter) ([]model.Project, int, error)
+	Get(ctx context.Context, id string) (*model.Project, error)
+	Create(ctx context.Context, p *model.Project) error
+	Update(ctx context.Context, p *model.Project) error
+	Delete(ctx context.Context, id string) error
+}

--- a/internal/infra/repository/project_repository.go
+++ b/internal/infra/repository/project_repository.go
@@ -1,0 +1,122 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+// ProjectRepository implements domrepo.ProjectRepository.
+type ProjectRepository struct {
+	DB *sql.DB
+}
+
+var _ domrepo.ProjectRepository = (*ProjectRepository)(nil)
+
+// Search returns projects matching filter with usage counts.
+func (r *ProjectRepository) Search(ctx context.Context, f domrepo.ProjectFilter) ([]model.Project, int, error) {
+	var args []any
+	var wheres []string
+	if f.Code != "" {
+		wheres = append(wheres, "project_code LIKE ?")
+		args = append(args, "%"+f.Code+"%")
+	}
+	if f.Name != "" {
+		wheres = append(wheres, "name LIKE ?")
+		args = append(args, "%"+f.Name+"%")
+	}
+	whereSQL := ""
+	if len(wheres) > 0 {
+		whereSQL = "WHERE " + strings.Join(wheres, " AND ")
+	}
+
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM projects %s", whereSQL)
+	row := r.DB.QueryRowContext(ctx, countQuery, args...)
+	var total int
+	if err := row.Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	offset := (f.Page - 1) * f.Size
+	listQuery := fmt.Sprintf(`SELECT id, project_code, name, department, manager, delivery_date, description, created_at, updated_at, (SELECT COUNT(*) FROM project_usages u WHERE u.project_id = projects.id) FROM projects %s ORDER BY created_at DESC LIMIT ? OFFSET ?`, whereSQL)
+	argsWithLimit := append(args, f.Size, offset)
+	rows, err := r.DB.QueryContext(ctx, listQuery, argsWithLimit...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var projects []model.Project
+	for rows.Next() {
+		var p model.Project
+		var dept, mgr, desc sql.NullString
+		var delivery sql.NullTime
+		var usageCount int
+		if err := rows.Scan(&p.ID, &p.ProjectCode, &p.Name, &dept, &mgr, &delivery, &desc, &p.CreatedAt, &p.UpdatedAt, &usageCount); err != nil {
+			return nil, 0, err
+		}
+		if dept.Valid {
+			p.Department = &dept.String
+		}
+		if mgr.Valid {
+			p.Manager = &mgr.String
+		}
+		if delivery.Valid {
+			p.DeliveryDate = &delivery.Time
+		}
+		if desc.Valid {
+			p.Description = &desc.String
+		}
+		p.OssUsageCount = usageCount
+		projects = append(projects, p)
+	}
+	return projects, total, rows.Err()
+}
+
+// Get returns a project by ID.
+func (r *ProjectRepository) Get(ctx context.Context, id string) (*model.Project, error) {
+	row := r.DB.QueryRowContext(ctx, `SELECT id, project_code, name, department, manager, delivery_date, description, created_at, updated_at, (SELECT COUNT(*) FROM project_usages u WHERE u.project_id = projects.id) FROM projects WHERE id = ?`, id)
+	var p model.Project
+	var dept, mgr, desc sql.NullString
+	var delivery sql.NullTime
+	var usageCount int
+	if err := row.Scan(&p.ID, &p.ProjectCode, &p.Name, &dept, &mgr, &delivery, &desc, &p.CreatedAt, &p.UpdatedAt, &usageCount); err != nil {
+		return nil, err
+	}
+	if dept.Valid {
+		p.Department = &dept.String
+	}
+	if mgr.Valid {
+		p.Manager = &mgr.String
+	}
+	if delivery.Valid {
+		p.DeliveryDate = &delivery.Time
+	}
+	if desc.Valid {
+		p.Description = &desc.String
+	}
+	p.OssUsageCount = usageCount
+	return &p, nil
+}
+
+// Create inserts a new project.
+func (r *ProjectRepository) Create(ctx context.Context, p *model.Project) error {
+	_, err := r.DB.ExecContext(ctx, `INSERT INTO projects (id, project_code, name, department, manager, delivery_date, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, p.ID, p.ProjectCode, p.Name, p.Department, p.Manager, p.DeliveryDate, p.Description, p.CreatedAt, p.UpdatedAt)
+	return err
+}
+
+// Update updates an existing project.
+func (r *ProjectRepository) Update(ctx context.Context, p *model.Project) error {
+	_, err := r.DB.ExecContext(ctx, `UPDATE projects SET name = ?, department = ?, manager = ?, delivery_date = ?, description = ?, updated_at = ? WHERE id = ?`, p.Name, p.Department, p.Manager, p.DeliveryDate, p.Description, p.UpdatedAt, p.ID)
+	return err
+}
+
+// Delete removes a project by ID.
+func (r *ProjectRepository) Delete(ctx context.Context, id string) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM projects WHERE id = ?`, id)
+	return err
+}

--- a/internal/infra/repository/project_repository_test.go
+++ b/internal/infra/repository/project_repository_test.go
@@ -1,0 +1,109 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+func TestProjectRepository_Search(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectRepository{DB: db}
+
+	f := domrepo.ProjectFilter{Code: "PRJ", Page: 1, Size: 10}
+
+	countQuery := regexp.QuoteMeta("SELECT COUNT(*) FROM projects WHERE project_code LIKE ?")
+	mock.ExpectQuery(countQuery).WithArgs("%PRJ%").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	listQuery := regexp.QuoteMeta("SELECT id, project_code, name, department, manager, delivery_date, description, created_at, updated_at, (SELECT COUNT(*) FROM project_usages u WHERE u.project_id = projects.id) FROM projects WHERE project_code LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?")
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{"id", "project_code", "name", "department", "manager", "delivery_date", "description", "created_at", "updated_at", "count"}).
+		AddRow(uuid.NewString(), "PRJ-1", "Proj", nil, nil, nil, nil, now, now, 0)
+	mock.ExpectQuery(listQuery).WithArgs("%PRJ%", 10, 0).WillReturnRows(rows)
+
+	res, total, err := repo.Search(context.Background(), f)
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, res, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectRepository_Get(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectRepository{DB: db}
+
+	id := uuid.NewString()
+	query := regexp.QuoteMeta("SELECT id, project_code, name, department, manager, delivery_date, description, created_at, updated_at, (SELECT COUNT(*) FROM project_usages u WHERE u.project_id = projects.id) FROM projects WHERE id = ?")
+	now := time.Now()
+	mock.ExpectQuery(query).WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"id", "project_code", "name", "department", "manager", "delivery_date", "description", "created_at", "updated_at", "count"}).
+		AddRow(id, "PRJ-1", "Proj", nil, nil, nil, nil, now, now, 0))
+
+	p, err := repo.Get(context.Background(), id)
+	require.NoError(t, err)
+	require.Equal(t, id, p.ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectRepository_Create(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectRepository{DB: db}
+
+	p := &model.Project{ID: uuid.NewString(), ProjectCode: "PRJ-1", Name: "Proj", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+
+	query := regexp.QuoteMeta("INSERT INTO projects (id, project_code, name, department, manager, delivery_date, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
+	mock.ExpectExec(query).WithArgs(p.ID, p.ProjectCode, p.Name, p.Department, p.Manager, p.DeliveryDate, p.Description, p.CreatedAt, p.UpdatedAt).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Create(context.Background(), p)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectRepository_Update(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectRepository{DB: db}
+
+	p := &model.Project{ID: uuid.NewString(), Name: "Proj", UpdatedAt: time.Now()}
+
+	query := regexp.QuoteMeta("UPDATE projects SET name = ?, department = ?, manager = ?, delivery_date = ?, description = ?, updated_at = ? WHERE id = ?")
+	mock.ExpectExec(query).WithArgs(p.Name, p.Department, p.Manager, p.DeliveryDate, p.Description, p.UpdatedAt, p.ID).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Update(context.Background(), p)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectRepository_Delete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectRepository{DB: db}
+
+	id := uuid.NewString()
+	query := regexp.QuoteMeta("DELETE FROM projects WHERE id = ?")
+	mock.ExpectExec(query).WithArgs(id).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Delete(context.Background(), id)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
- add Project domain model and repository interface
- implement SQL repository for projects with usage count
- cover repository CRUD operations with go-sqlmock tests

## Testing
- `go vet ./...`
- `go test ./...`
- `go generate ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ced0afc3c83208017e318e415889b