### PR TITLE
Implement project usage repository

### DIFF
--- a/internal/domain/model/project_usage.go
+++ b/internal/domain/model/project_usage.go
@@ -1,0 +1,20 @@
+package model
+
+import "time"
+
+// ProjectUsage represents OSS usage within a project.
+type ProjectUsage struct {
+	ID               string
+	ProjectID        string
+	OssID            string
+	OssVersionID     string
+	UsageRole        string
+	ScopeStatus      string
+	InclusionNote    *string
+	DirectDependency bool
+	AddedAt          time.Time
+	EvaluatedAt      *time.Time
+	EvaluatedBy      *string
+}
+
+// ProjectUsageFilter not defined here - in repository package.

--- a/internal/domain/repository/project_usage_repository.go
+++ b/internal/domain/repository/project_usage_repository.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+)
+
+// ProjectUsageFilter filters usage listing.
+type ProjectUsageFilter struct {
+	ProjectID   string
+	ScopeStatus string
+	UsageRole   string
+	Direct      *bool
+	Page        int
+	Size        int
+}
+
+// ProjectUsageRepository defines DB operations for ProjectUsage.
+type ProjectUsageRepository interface {
+	Search(ctx context.Context, f ProjectUsageFilter) ([]model.ProjectUsage, int, error)
+	Create(ctx context.Context, u *model.ProjectUsage) error
+	Update(ctx context.Context, u *model.ProjectUsage) error
+	Delete(ctx context.Context, id string) error
+	UpdateScope(ctx context.Context, id string, scopeStatus string, inclusionNote *string, evaluatedAt time.Time, evaluatedBy *string) error
+}

--- a/internal/infra/repository/project_usage_repository.go
+++ b/internal/infra/repository/project_usage_repository.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+// ProjectUsageRepository implements domrepo.ProjectUsageRepository.
+type ProjectUsageRepository struct {
+	DB *sql.DB
+}
+
+var _ domrepo.ProjectUsageRepository = (*ProjectUsageRepository)(nil)
+
+// Search returns project usages matching filter.
+func (r *ProjectUsageRepository) Search(ctx context.Context, f domrepo.ProjectUsageFilter) ([]model.ProjectUsage, int, error) {
+	var args []any
+	wheres := []string{"project_id = ?"}
+	args = append(args, f.ProjectID)
+	if f.ScopeStatus != "" {
+		wheres = append(wheres, "scope_status = ?")
+		args = append(args, f.ScopeStatus)
+	}
+	if f.UsageRole != "" {
+		wheres = append(wheres, "usage_role = ?")
+		args = append(args, f.UsageRole)
+	}
+	if f.Direct != nil {
+		wheres = append(wheres, "direct_dependency = ?")
+		args = append(args, *f.Direct)
+	}
+	whereSQL := "WHERE " + strings.Join(wheres, " AND ")
+
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM project_usages %s", whereSQL)
+	row := r.DB.QueryRowContext(ctx, countQuery, args...)
+	var total int
+	if err := row.Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	offset := (f.Page - 1) * f.Size
+	listQuery := fmt.Sprintf(`SELECT id, project_id, oss_id, oss_version_id, usage_role, scope_status, inclusion_note, direct_dependency, added_at, evaluated_at, evaluated_by FROM project_usages %s ORDER BY added_at DESC LIMIT ? OFFSET ?`, whereSQL)
+	argsWithLimit := append(args, f.Size, offset)
+	rows, err := r.DB.QueryContext(ctx, listQuery, argsWithLimit...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var usages []model.ProjectUsage
+	for rows.Next() {
+		var u model.ProjectUsage
+		var note, evalBy sql.NullString
+		var evalAt sql.NullTime
+		if err := rows.Scan(&u.ID, &u.ProjectID, &u.OssID, &u.OssVersionID, &u.UsageRole, &u.ScopeStatus, &note, &u.DirectDependency, &u.AddedAt, &evalAt, &evalBy); err != nil {
+			return nil, 0, err
+		}
+		if note.Valid {
+			u.InclusionNote = &note.String
+		}
+		if evalAt.Valid {
+			u.EvaluatedAt = &evalAt.Time
+		}
+		if evalBy.Valid {
+			u.EvaluatedBy = &evalBy.String
+		}
+		usages = append(usages, u)
+	}
+	return usages, total, rows.Err()
+}
+
+// Create inserts a new project usage.
+func (r *ProjectUsageRepository) Create(ctx context.Context, u *model.ProjectUsage) error {
+	query := `INSERT INTO project_usages (id, project_id, oss_id, oss_version_id, usage_role, scope_status, inclusion_note, direct_dependency, added_at, evaluated_at, evaluated_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err := r.DB.ExecContext(ctx, query, u.ID, u.ProjectID, u.OssID, u.OssVersionID, u.UsageRole, u.ScopeStatus, u.InclusionNote, u.DirectDependency, u.AddedAt, u.EvaluatedAt, u.EvaluatedBy)
+	return err
+}
+
+// Update updates an existing usage.
+func (r *ProjectUsageRepository) Update(ctx context.Context, u *model.ProjectUsage) error {
+	query := `UPDATE project_usages SET oss_version_id = ?, usage_role = ?, direct_dependency = ?, inclusion_note = ?, scope_status = ?, evaluated_at = ?, evaluated_by = ? WHERE id = ?`
+	_, err := r.DB.ExecContext(ctx, query, u.OssVersionID, u.UsageRole, u.DirectDependency, u.InclusionNote, u.ScopeStatus, u.EvaluatedAt, u.EvaluatedBy, u.ID)
+	return err
+}
+
+// Delete removes a usage by ID.
+func (r *ProjectUsageRepository) Delete(ctx context.Context, id string) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM project_usages WHERE id = ?`, id)
+	return err
+}
+
+// UpdateScope updates only scope related fields.
+func (r *ProjectUsageRepository) UpdateScope(ctx context.Context, id string, scopeStatus string, inclusionNote *string, evaluatedAt time.Time, evaluatedBy *string) error {
+	query := `UPDATE project_usages SET scope_status = ?, inclusion_note = ?, evaluated_at = ?, evaluated_by = ? WHERE id = ?`
+	_, err := r.DB.ExecContext(ctx, query, scopeStatus, inclusionNote, evaluatedAt, evaluatedBy, id)
+	return err
+}

--- a/internal/infra/repository/project_usage_repository_test.go
+++ b/internal/infra/repository/project_usage_repository_test.go
@@ -1,0 +1,133 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+func TestProjectUsageRepository_Search(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectUsageRepository{DB: db}
+
+	pid := uuid.NewString()
+	f := domrepo.ProjectUsageFilter{ProjectID: pid, Page: 1, Size: 10}
+
+	countQuery := regexp.QuoteMeta("SELECT COUNT(*) FROM project_usages WHERE project_id = ?")
+	mock.ExpectQuery(countQuery).WithArgs(pid).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	listQuery := regexp.QuoteMeta("SELECT id, project_id, oss_id, oss_version_id, usage_role, scope_status, inclusion_note, direct_dependency, added_at, evaluated_at, evaluated_by FROM project_usages WHERE project_id = ? ORDER BY added_at DESC LIMIT ? OFFSET ?")
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{"id", "project_id", "oss_id", "oss_version_id", "usage_role", "scope_status", "inclusion_note", "direct_dependency", "added_at", "evaluated_at", "evaluated_by"}).
+		AddRow(uuid.NewString(), pid, uuid.NewString(), uuid.NewString(), "RUNTIME_REQUIRED", "IN_SCOPE", nil, true, now, nil, nil)
+	mock.ExpectQuery(listQuery).WithArgs(pid, 10, 0).WillReturnRows(rows)
+
+	res, total, err := repo.Search(context.Background(), f)
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, res, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectUsageRepository_Create(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectUsageRepository{DB: db}
+
+	u := &model.ProjectUsage{
+		ID:               uuid.NewString(),
+		ProjectID:        uuid.NewString(),
+		OssID:            uuid.NewString(),
+		OssVersionID:     uuid.NewString(),
+		UsageRole:        "RUNTIME_REQUIRED",
+		ScopeStatus:      "IN_SCOPE",
+		DirectDependency: true,
+		AddedAt:          time.Now(),
+	}
+
+	query := regexp.QuoteMeta("INSERT INTO project_usages (id, project_id, oss_id, oss_version_id, usage_role, scope_status, inclusion_note, direct_dependency, added_at, evaluated_at, evaluated_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+	mock.ExpectExec(query).
+		WithArgs(u.ID, u.ProjectID, u.OssID, u.OssVersionID, u.UsageRole, u.ScopeStatus, u.InclusionNote, u.DirectDependency, u.AddedAt, u.EvaluatedAt, u.EvaluatedBy).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Create(context.Background(), u)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectUsageRepository_Update(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectUsageRepository{DB: db}
+
+	u := &model.ProjectUsage{
+		ID:               uuid.NewString(),
+		OssVersionID:     uuid.NewString(),
+		UsageRole:        "BUNDLED_SOURCE",
+		DirectDependency: false,
+		InclusionNote:    func() *string { s := "note"; return &s }(),
+		ScopeStatus:      "IN_SCOPE",
+		EvaluatedAt:      func() *time.Time { t := time.Now(); return &t }(),
+		EvaluatedBy:      func() *string { s := "user"; return &s }(),
+	}
+
+	query := regexp.QuoteMeta("UPDATE project_usages SET oss_version_id = ?, usage_role = ?, direct_dependency = ?, inclusion_note = ?, scope_status = ?, evaluated_at = ?, evaluated_by = ? WHERE id = ?")
+	mock.ExpectExec(query).
+		WithArgs(u.OssVersionID, u.UsageRole, u.DirectDependency, u.InclusionNote, u.ScopeStatus, u.EvaluatedAt, u.EvaluatedBy, u.ID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Update(context.Background(), u)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectUsageRepository_Delete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectUsageRepository{DB: db}
+
+	id := uuid.NewString()
+	query := regexp.QuoteMeta("DELETE FROM project_usages WHERE id = ?")
+	mock.ExpectExec(query).WithArgs(id).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Delete(context.Background(), id)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectUsageRepository_UpdateScope(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &ProjectUsageRepository{DB: db}
+
+	id := uuid.NewString()
+	inclusion := "reason"
+	evalBy := "user"
+	now := time.Now()
+
+	query := regexp.QuoteMeta("UPDATE project_usages SET scope_status = ?, inclusion_note = ?, evaluated_at = ?, evaluated_by = ? WHERE id = ?")
+	mock.ExpectExec(query).WithArgs("OUT_SCOPE", &inclusion, now, &evalBy, id).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.UpdateScope(context.Background(), id, "OUT_SCOPE", &inclusion, now, &evalBy)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
- implement domain model for project usages
- add repository interface and SQL implementation
- support listing/creating/updating/deleting project usages
- add unit tests using go-sqlmock

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cf26e50a083209a92e002b5b5fa06