### PR TITLE
Implement audit log repository and handler

### DIFF
--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -1,19 +1,51 @@
 package handler
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
 )
 
 type Handler struct {
+	AuditRepo domrepo.AuditLogRepository
 }
 
 // 監査ログ簡易検索 (Phase1簡易)
 // (GET /audit)
-func (*Handler) SearchAuditLogs(ctx echo.Context, params gen.SearchAuditLogsParams) error {
-	return nil
+func (h *Handler) SearchAuditLogs(ctx echo.Context, params gen.SearchAuditLogsParams) error {
+	filter := domrepo.AuditLogFilter{
+		EntityType: params.EntityType,
+		EntityID:   params.EntityId,
+		From:       params.From,
+		To:         params.To,
+	}
+
+	logs, err := h.AuditRepo.Search(ctx.Request().Context(), filter)
+	if err != nil {
+		return err
+	}
+
+	items := make([]map[string]any, len(logs))
+	for i, l := range logs {
+		item := map[string]any{
+			"id":         l.ID,
+			"entityType": l.EntityType,
+			"entityId":   l.EntityID,
+			"action":     l.Action,
+			"at":         l.CreatedAt,
+			"user":       l.UserName,
+		}
+		if l.Summary != nil {
+			item["summary"] = *l.Summary
+		}
+		items[i] = item
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]any{"items": items})
 }
 
 // OSSコンポーネント一覧取得

--- a/internal/domain/model/audit_log.go
+++ b/internal/domain/model/audit_log.go
@@ -1,0 +1,14 @@
+package model
+
+import "time"
+
+// AuditLog represents a single audit event.
+type AuditLog struct {
+	ID         string
+	EntityType string
+	EntityID   string
+	Action     string
+	UserName   string
+	Summary    *string
+	CreatedAt  time.Time
+}

--- a/internal/domain/repository/audit_log_repository.go
+++ b/internal/domain/repository/audit_log_repository.go
@@ -1,0 +1,22 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+)
+
+// AuditLogFilter filters audit log search.
+type AuditLogFilter struct {
+	EntityType *string
+	EntityID   *string
+	From       *time.Time
+	To         *time.Time
+}
+
+// AuditLogRepository defines DB operations for AuditLog.
+type AuditLogRepository interface {
+	Search(ctx context.Context, f AuditLogFilter) ([]model.AuditLog, error)
+	Create(ctx context.Context, l *model.AuditLog) error
+}

--- a/internal/infra/repository/audit_log_repository.go
+++ b/internal/infra/repository/audit_log_repository.go
@@ -1,0 +1,73 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+// AuditLogRepository implements domrepo.AuditLogRepository.
+type AuditLogRepository struct {
+	DB *sql.DB
+}
+
+var _ domrepo.AuditLogRepository = (*AuditLogRepository)(nil)
+
+// Search returns audit logs matching filter ordered by created_at desc.
+func (r *AuditLogRepository) Search(ctx context.Context, f domrepo.AuditLogFilter) ([]model.AuditLog, error) {
+	var args []any
+	var wheres []string
+	if f.EntityType != nil && *f.EntityType != "" {
+		wheres = append(wheres, "entity_type = ?")
+		args = append(args, *f.EntityType)
+	}
+	if f.EntityID != nil && *f.EntityID != "" {
+		wheres = append(wheres, "entity_id = ?")
+		args = append(args, *f.EntityID)
+	}
+	if f.From != nil {
+		wheres = append(wheres, "created_at >= ?")
+		args = append(args, *f.From)
+	}
+	if f.To != nil {
+		wheres = append(wheres, "created_at <= ?")
+		args = append(args, *f.To)
+	}
+	whereSQL := ""
+	if len(wheres) > 0 {
+		whereSQL = "WHERE " + strings.Join(wheres, " AND ")
+	}
+	query := fmt.Sprintf("SELECT id, entity_type, entity_id, action, user_name, summary, created_at FROM audit_logs %s ORDER BY created_at DESC", whereSQL)
+	rows, err := r.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var logs []model.AuditLog
+	for rows.Next() {
+		var l model.AuditLog
+		var summary sql.NullString
+		if err := rows.Scan(&l.ID, &l.EntityType, &l.EntityID, &l.Action, &l.UserName, &summary, &l.CreatedAt); err != nil {
+			return nil, err
+		}
+		if summary.Valid {
+			l.Summary = &summary.String
+		}
+		logs = append(logs, l)
+	}
+	return logs, rows.Err()
+}
+
+// Create inserts a new audit log entry.
+func (r *AuditLogRepository) Create(ctx context.Context, l *model.AuditLog) error {
+	_, err := r.DB.ExecContext(ctx,
+		`INSERT INTO audit_logs (id, entity_type, entity_id, action, user_name, summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		l.ID, l.EntityType, l.EntityID, l.Action, l.UserName, l.Summary, l.CreatedAt,
+	)
+	return err
+}

--- a/internal/infra/repository/audit_log_repository_test.go
+++ b/internal/infra/repository/audit_log_repository_test.go
@@ -1,0 +1,62 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+func TestAuditLogRepository_Search(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &AuditLogRepository{DB: db}
+
+	f := domrepo.AuditLogFilter{EntityType: func() *string { s := "PROJECT"; return &s }()}
+
+	query := regexp.QuoteMeta("SELECT id, entity_type, entity_id, action, user_name, summary, created_at FROM audit_logs WHERE entity_type = ? ORDER BY created_at DESC")
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{"id", "entity_type", "entity_id", "action", "user_name", "summary", "created_at"}).
+		AddRow(uuid.NewString(), "PROJECT", "1", "CREATE", "user", "created", now)
+	mock.ExpectQuery(query).WithArgs("PROJECT").WillReturnRows(rows)
+
+	logs, err := repo.Search(context.Background(), f)
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAuditLogRepository_Create(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &AuditLogRepository{DB: db}
+
+	l := &model.AuditLog{
+		ID:         uuid.NewString(),
+		EntityType: "PROJECT",
+		EntityID:   "1",
+		Action:     "CREATE",
+		UserName:   "user",
+		CreatedAt:  time.Now(),
+	}
+
+	query := regexp.QuoteMeta("INSERT INTO audit_logs (id, entity_type, entity_id, action, user_name, summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
+	mock.ExpectExec(query).
+		WithArgs(l.ID, l.EntityType, l.EntityID, l.Action, l.UserName, l.Summary, l.CreatedAt).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = repo.Create(context.Background(), l)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
- add AuditLog model and repository interface
- implement SQL repository for audit_logs table with search/insert
- expose AuditLog search via handler
- test repository using go-sqlmock

## Testing
- `go generate ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cf7d39434832082e5d81eef296960