### PR TITLE
Implement oss_component_tags repository

### DIFF
--- a/internal/domain/repository/oss_component_tag_repository.go
+++ b/internal/domain/repository/oss_component_tag_repository.go
@@ -1,0 +1,15 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+)
+
+// OssComponentTagRepository defines operations on oss_component_tags table.
+type OssComponentTagRepository interface {
+	// ListByOssID returns tags associated with a component ordered by created_at.
+	ListByOssID(ctx context.Context, ossID string) ([]model.Tag, error)
+	// Replace replaces tags for a component with given tagIDs.
+	Replace(ctx context.Context, ossID string, tagIDs []string) error
+}

--- a/internal/infra/repository/oss_component_tag_repository.go
+++ b/internal/infra/repository/oss_component_tag_repository.go
@@ -1,0 +1,60 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+// OssComponentTagRepository implements domrepo.OssComponentTagRepository.
+type OssComponentTagRepository struct {
+	DB *sql.DB
+}
+
+var _ domrepo.OssComponentTagRepository = (*OssComponentTagRepository)(nil)
+
+// ListByOssID returns tags associated with the given component ordered by created_at.
+func (r *OssComponentTagRepository) ListByOssID(ctx context.Context, ossID string) ([]model.Tag, error) {
+	rows, err := r.DB.QueryContext(ctx,
+		`SELECT tg.id, tg.name, tg.created_at FROM tags tg
+         JOIN oss_component_tags ct ON ct.tag_id = tg.id
+         WHERE ct.oss_id = ? ORDER BY tg.created_at DESC`, ossID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tags []model.Tag
+	for rows.Next() {
+		var t model.Tag
+		var created time.Time
+		if err := rows.Scan(&t.ID, &t.Name, &created); err != nil {
+			return nil, err
+		}
+		t.CreatedAt = &created
+		tags = append(tags, t)
+	}
+	return tags, rows.Err()
+}
+
+// Replace replaces tags for a component with provided IDs.
+func (r *OssComponentTagRepository) Replace(ctx context.Context, ossID string, tagIDs []string) error {
+	tx, err := r.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM oss_component_tags WHERE oss_id = ?`, ossID); err != nil {
+		tx.Rollback()
+		return err
+	}
+	for _, id := range tagIDs {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO oss_component_tags (oss_id, tag_id) VALUES (?, ?)`, ossID, id); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}

--- a/internal/infra/repository/oss_component_tag_repository_test.go
+++ b/internal/infra/repository/oss_component_tag_repository_test.go
@@ -1,0 +1,55 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOssComponentTagRepository_ListByOssID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssComponentTagRepository{DB: db}
+
+	ossID := uuid.NewString()
+	query := regexp.QuoteMeta(`SELECT tg.id, tg.name, tg.created_at FROM tags tg JOIN oss_component_tags ct ON ct.tag_id = tg.id WHERE ct.oss_id = ? ORDER BY tg.created_at DESC`)
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{"id", "name", "created_at"}).AddRow(uuid.NewString(), "db", now)
+	mock.ExpectQuery(query).WithArgs(ossID).WillReturnRows(rows)
+
+	tags, err := repo.ListByOssID(context.Background(), ossID)
+	require.NoError(t, err)
+	require.Len(t, tags, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOssComponentTagRepository_Replace(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssComponentTagRepository{DB: db}
+
+	ossID := uuid.NewString()
+	tagIDs := []string{uuid.NewString(), uuid.NewString()}
+
+	mock.ExpectBegin()
+	delQuery := regexp.QuoteMeta(`DELETE FROM oss_component_tags WHERE oss_id = ?`)
+	mock.ExpectExec(delQuery).WithArgs(ossID).WillReturnResult(sqlmock.NewResult(1, 1))
+	insQuery := regexp.QuoteMeta(`INSERT INTO oss_component_tags (oss_id, tag_id) VALUES (?, ?)`)
+	for _, id := range tagIDs {
+		mock.ExpectExec(insQuery).WithArgs(ossID, id).WillReturnResult(sqlmock.NewResult(1, 1))
+	}
+	mock.ExpectCommit()
+
+	err = repo.Replace(context.Background(), ossID, tagIDs)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
- add `OssComponentTagRepository` interface
- implement repository to list and replace tags for an OSS component
- provide unit tests with go-sqlmock

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cfd1ab1d08320bf14bd4991a79620