### PR TITLE
Add oss_component_layers repository

### DIFF
--- a/internal/domain/repository/oss_component_layer_repository.go
+++ b/internal/domain/repository/oss_component_layer_repository.go
@@ -1,0 +1,11 @@
+package repository
+
+import "context"
+
+// OssComponentLayerRepository defines operations on oss_component_layers table.
+type OssComponentLayerRepository interface {
+	// ListByOssID returns layers associated with a component ordered by layer.
+	ListByOssID(ctx context.Context, ossID string) ([]string, error)
+	// Replace replaces layers for a component with given layers.
+	Replace(ctx context.Context, ossID string, layers []string) error
+}

--- a/internal/infra/repository/oss_component_layer_repository.go
+++ b/internal/infra/repository/oss_component_layer_repository.go
@@ -1,0 +1,56 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+)
+
+// OssComponentLayerRepository implements domrepo.OssComponentLayerRepository.
+type OssComponentLayerRepository struct {
+	DB *sql.DB
+}
+
+var _ domrepo.OssComponentLayerRepository = (*OssComponentLayerRepository)(nil)
+
+// ListByOssID returns layers associated with the given component ordered by layer name.
+func (r *OssComponentLayerRepository) ListByOssID(ctx context.Context, ossID string) ([]string, error) {
+	rows, err := r.DB.QueryContext(ctx,
+		`SELECT layer FROM oss_component_layers WHERE oss_id = ? ORDER BY layer`,
+		ossID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var layers []string
+	for rows.Next() {
+		var layer string
+		if err := rows.Scan(&layer); err != nil {
+			return nil, err
+		}
+		layers = append(layers, layer)
+	}
+	return layers, rows.Err()
+}
+
+// Replace replaces layers for a component with the given layers.
+func (r *OssComponentLayerRepository) Replace(ctx context.Context, ossID string, layers []string) error {
+	tx, err := r.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM oss_component_layers WHERE oss_id = ?`, ossID); err != nil {
+		tx.Rollback()
+		return err
+	}
+	for _, l := range layers {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO oss_component_layers (oss_id, layer) VALUES (?, ?)`, ossID, l); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}

--- a/internal/infra/repository/oss_component_layer_repository_test.go
+++ b/internal/infra/repository/oss_component_layer_repository_test.go
@@ -1,0 +1,53 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOssComponentLayerRepository_ListByOssID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssComponentLayerRepository{DB: db}
+
+	ossID := uuid.NewString()
+	query := regexp.QuoteMeta(`SELECT layer FROM oss_component_layers WHERE oss_id = ? ORDER BY layer`)
+	rows := sqlmock.NewRows([]string{"layer"}).AddRow("LIB").AddRow("DB")
+	mock.ExpectQuery(query).WithArgs(ossID).WillReturnRows(rows)
+
+	layers, err := repo.ListByOssID(context.Background(), ossID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"LIB", "DB"}, layers)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOssComponentLayerRepository_Replace(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &OssComponentLayerRepository{DB: db}
+
+	ossID := uuid.NewString()
+	layers := []string{"LIB", "DB"}
+
+	mock.ExpectBegin()
+	delQuery := regexp.QuoteMeta(`DELETE FROM oss_component_layers WHERE oss_id = ?`)
+	mock.ExpectExec(delQuery).WithArgs(ossID).WillReturnResult(sqlmock.NewResult(1, 1))
+	insQuery := regexp.QuoteMeta(`INSERT INTO oss_component_layers (oss_id, layer) VALUES (?, ?)`)
+	for _, l := range layers {
+		mock.ExpectExec(insQuery).WithArgs(ossID, l).WillReturnResult(sqlmock.NewResult(1, 1))
+	}
+	mock.ExpectCommit()
+
+	err = repo.Replace(context.Background(), ossID, layers)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
- implement repository interface for `oss_component_layers`
- add SQL implementation to list and replace layers
- cover new repository with `sqlmock` tests

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687cfe9e0a9c8320b354145b9f491a71