### PR TITLE
Implement OSS handlers and tests

### DIFF
--- a/internal/api/handler/hanlder.go
+++ b/internal/api/handler/hanlder.go
@@ -8,6 +8,10 @@ import (
 )
 
 type Handler struct {
-	AuditRepo       domrepo.AuditLogRepository
-	ScopePolicyRepo domrepo.ScopePolicyRepository
+	AuditRepo             domrepo.AuditLogRepository
+	ScopePolicyRepo       domrepo.ScopePolicyRepository
+	OssComponentRepo      domrepo.OssComponentRepository
+	OssComponentLayerRepo domrepo.OssComponentLayerRepository
+	OssComponentTagRepo   domrepo.OssComponentTagRepository
+	OssVersionRepo        domrepo.OssVersionRepository
 }

--- a/internal/api/handler/oss_handler.go
+++ b/internal/api/handler/oss_handler.go
@@ -3,22 +3,228 @@ package handler
 // oss_handler.go - /oss に関するハンドラ処理
 
 import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
 )
+
+func toOssComponent(m model.OssComponent) gen.OssComponent {
+	uid := uuid.MustParse(m.ID)
+	res := gen.OssComponent{
+		Id:         uid,
+		Name:       m.Name,
+		Deprecated: m.Deprecated,
+		CreatedAt:  m.CreatedAt,
+		UpdatedAt:  m.UpdatedAt,
+	}
+	if m.NormalizedName != "" {
+		res.NormalizedName = &m.NormalizedName
+	}
+	if m.HomepageURL != nil {
+		res.HomepageUrl = m.HomepageURL
+	}
+	if m.RepositoryURL != nil {
+		res.RepositoryUrl = m.RepositoryURL
+	}
+	if m.Description != nil {
+		res.Description = m.Description
+	}
+	if m.PrimaryLanguage != nil {
+		res.PrimaryLanguage = m.PrimaryLanguage
+	}
+	if len(m.Layers) > 0 {
+		layers := make([]gen.Layer, len(m.Layers))
+		for i, l := range m.Layers {
+			layers[i] = gen.Layer(l)
+		}
+		res.Layers = &layers
+	}
+	if m.DefaultUsageRole != nil {
+		val := gen.UsageRole(*m.DefaultUsageRole)
+		res.DefaultUsageRole = &val
+	}
+	if len(m.Tags) > 0 {
+		tags := make([]gen.Tag, len(m.Tags))
+		for i, t := range m.Tags {
+			tags[i] = gen.Tag{Id: uuid.MustParse(t.ID), Name: t.Name}
+		}
+		res.Tags = &tags
+	}
+	return res
+}
+
+func toOssVersion(m model.OssVersion) gen.OssVersion {
+	uid := uuid.MustParse(m.ID)
+	ossUID := uuid.MustParse(m.OssID)
+	res := gen.OssVersion{
+		Id:           uid,
+		OssId:        ossUID,
+		Version:      m.Version,
+		Modified:     m.Modified,
+		ReviewStatus: gen.ReviewStatus(m.ReviewStatus),
+		ScopeStatus:  gen.ScopeStatus(m.ScopeStatus),
+		CreatedAt:    m.CreatedAt,
+		UpdatedAt:    m.UpdatedAt,
+	}
+	if m.ReleaseDate != nil {
+		res.ReleaseDate = &openapi_types.Date{Time: *m.ReleaseDate}
+	}
+	if m.LicenseExpressionRaw != nil {
+		res.LicenseExpressionRaw = m.LicenseExpressionRaw
+	}
+	if m.LicenseConcluded != nil {
+		res.LicenseConcluded = m.LicenseConcluded
+	}
+	if m.Purl != nil {
+		res.Purl = m.Purl
+	}
+	if len(m.CpeList) > 0 {
+		list := make([]string, len(m.CpeList))
+		copy(list, m.CpeList)
+		res.CpeList = &list
+	}
+	if m.HashSha256 != nil {
+		res.HashSha256 = m.HashSha256
+	}
+	if m.ModificationDescription != nil {
+		res.ModificationDescription = m.ModificationDescription
+	}
+	if m.LastReviewedAt != nil {
+		res.LastReviewedAt = m.LastReviewedAt
+	}
+	if m.SupplierType != nil {
+		val := gen.SupplierType(*m.SupplierType)
+		res.SupplierType = &val
+	}
+	if m.ForkOriginURL != nil {
+		res.ForkOriginUrl = m.ForkOriginURL
+	}
+	return res
+}
 
 // OSSコンポーネント一覧取得
 // (GET /oss)
-func (*Handler) ListOssComponents(ctx echo.Context, params gen.ListOssComponentsParams) error {
-	return nil
+func (h *Handler) ListOssComponents(ctx echo.Context, params gen.ListOssComponentsParams) error {
+	page := 1
+	if params.Page != nil {
+		page = int(*params.Page)
+	}
+	size := 50
+	if params.Size != nil {
+		size = int(*params.Size)
+	}
+	f := domrepo.OssComponentFilter{Page: page, Size: size}
+	if params.Name != nil {
+		f.Name = *params.Name
+	}
+	if params.Layers != nil && *params.Layers != "" {
+		f.Layers = strings.Split(*params.Layers, ",")
+	}
+	if params.Tag != nil {
+		f.Tag = *params.Tag
+	}
+	if params.InScopeOnly != nil {
+		f.InScopeOnly = *params.InScopeOnly
+	}
+
+	comps, total, err := h.OssComponentRepo.Search(ctx.Request().Context(), f)
+	if err != nil {
+		return err
+	}
+
+	for i := range comps {
+		layers, err := h.OssComponentLayerRepo.ListByOssID(ctx.Request().Context(), comps[i].ID)
+		if err != nil {
+			return err
+		}
+		comps[i].Layers = layers
+		tags, err := h.OssComponentTagRepo.ListByOssID(ctx.Request().Context(), comps[i].ID)
+		if err != nil {
+			return err
+		}
+		comps[i].Tags = tags
+	}
+
+	items := make([]gen.OssComponent, len(comps))
+	for i, c := range comps {
+		items[i] = toOssComponent(c)
+	}
+	res := gen.PagedResultOssComponent{
+		Items: &items,
+		Page:  &page,
+		Size:  &size,
+		Total: &total,
+	}
+	return ctx.JSON(http.StatusOK, res)
 }
 
 // OSSコンポーネント作成
 // (POST /oss)
-func (*Handler) CreateOssComponent(ctx echo.Context) error {
-	return nil
+func (h *Handler) CreateOssComponent(ctx echo.Context) error {
+	var req gen.OssComponentCreateRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid body")
+	}
+	now := time.Now()
+	id := uuid.NewString()
+	comp := &model.OssComponent{
+		ID:              id,
+		Name:            req.Name,
+		NormalizedName:  strings.ToLower(req.Name),
+		HomepageURL:     req.HomepageUrl,
+		RepositoryURL:   req.RepositoryUrl,
+		Description:     req.Description,
+		PrimaryLanguage: req.PrimaryLanguage,
+		Deprecated:      false,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if req.DefaultUsageRole != nil {
+		val := string(*req.DefaultUsageRole)
+		comp.DefaultUsageRole = &val
+	}
+	if req.Layers != nil {
+		ls := make([]string, len(*req.Layers))
+		for i, l := range *req.Layers {
+			ls[i] = string(l)
+		}
+		comp.Layers = ls
+	}
+
+	if err := h.OssComponentRepo.Create(ctx.Request().Context(), comp); err != nil {
+		return err
+	}
+	if len(comp.Layers) > 0 {
+		if err := h.OssComponentLayerRepo.Replace(ctx.Request().Context(), comp.ID, comp.Layers); err != nil {
+			return err
+		}
+	}
+	if req.TagIds != nil {
+		ids := make([]string, len(*req.TagIds))
+		for i, tid := range *req.TagIds {
+			ids[i] = tid.String()
+		}
+		if err := h.OssComponentTagRepo.Replace(ctx.Request().Context(), comp.ID, ids); err != nil {
+			return err
+		}
+	}
+	tags, err := h.OssComponentTagRepo.ListByOssID(ctx.Request().Context(), comp.ID)
+	if err != nil {
+		return err
+	}
+	comp.Tags = tags
+	res := toOssComponent(*comp)
+	return ctx.JSON(http.StatusCreated, res)
 }
 
 // OSSコンポーネントを非推奨 (deprecated=true) に設定
@@ -41,30 +247,175 @@ func (*Handler) UpdateOssComponent(ctx echo.Context, ossId openapi_types.UUID) e
 
 // 指定 OSS のバージョン一覧
 // (GET /oss/{ossId}/versions)
-func (*Handler) ListOssVersions(ctx echo.Context, ossId openapi_types.UUID, params gen.ListOssVersionsParams) error {
-	return nil
+func (h *Handler) ListOssVersions(ctx echo.Context, ossId openapi_types.UUID, params gen.ListOssVersionsParams) error {
+	page := 1
+	if params.Page != nil {
+		page = int(*params.Page)
+	}
+	size := 50
+	if params.Size != nil {
+		size = int(*params.Size)
+	}
+	f := domrepo.OssVersionFilter{
+		OssID: ossId.String(),
+		Page:  page,
+		Size:  size,
+	}
+	if params.ReviewStatus != nil {
+		f.ReviewStatus = string(*params.ReviewStatus)
+	}
+	if params.ScopeStatus != nil {
+		f.ScopeStatus = string(*params.ScopeStatus)
+	}
+	vers, total, err := h.OssVersionRepo.Search(ctx.Request().Context(), f)
+	if err != nil {
+		return err
+	}
+	items := make([]gen.OssVersion, len(vers))
+	for i, v := range vers {
+		items[i] = toOssVersion(v)
+	}
+	res := gen.PagedResultOssVersion{
+		Items: &items,
+		Page:  &page,
+		Size:  &size,
+		Total: &total,
+	}
+	return ctx.JSON(http.StatusOK, res)
 }
 
 // バージョン追加
 // (POST /oss/{ossId}/versions)
-func (*Handler) CreateOssVersion(ctx echo.Context, ossId openapi_types.UUID) error {
-	return nil
+func (h *Handler) CreateOssVersion(ctx echo.Context, ossId openapi_types.UUID) error {
+	var req gen.OssVersionCreateRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid body")
+	}
+	now := time.Now()
+	v := &model.OssVersion{
+		ID:           uuid.NewString(),
+		OssID:        ossId.String(),
+		Version:      req.Version,
+		ReviewStatus: "draft",
+		ScopeStatus:  string(gen.INSCOPE),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if req.ReleaseDate != nil {
+		t := req.ReleaseDate.Time
+		v.ReleaseDate = &t
+	}
+	if req.LicenseExpressionRaw != nil {
+		v.LicenseExpressionRaw = req.LicenseExpressionRaw
+	}
+	if req.Purl != nil {
+		v.Purl = req.Purl
+	}
+	if req.CpeList != nil {
+		v.CpeList = *req.CpeList
+	}
+	if req.HashSha256 != nil {
+		v.HashSha256 = req.HashSha256
+	}
+	if req.Modified != nil {
+		v.Modified = *req.Modified
+	}
+	if req.ModificationDescription != nil {
+		v.ModificationDescription = req.ModificationDescription
+	}
+	if req.SupplierType != nil {
+		val := string(*req.SupplierType)
+		v.SupplierType = &val
+	}
+	if req.ForkOriginUrl != nil {
+		v.ForkOriginURL = req.ForkOriginUrl
+	}
+	if err := h.OssVersionRepo.Create(ctx.Request().Context(), v); err != nil {
+		return err
+	}
+	res := toOssVersion(*v)
+	return ctx.JSON(http.StatusCreated, res)
 }
 
 // バージョン削除 (論理/物理は実装方針による)
 // (DELETE /oss/{ossId}/versions/{versionId})
-func (*Handler) DeleteOssVersion(ctx echo.Context, ossId openapi_types.UUID, versionId openapi_types.UUID) error {
-	return nil
+func (h *Handler) DeleteOssVersion(ctx echo.Context, ossId openapi_types.UUID, versionId openapi_types.UUID) error {
+	if err := h.OssVersionRepo.Delete(ctx.Request().Context(), versionId.String()); err != nil {
+		return err
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 // バージョン詳細
 // (GET /oss/{ossId}/versions/{versionId})
-func (*Handler) GetOssVersion(ctx echo.Context, ossId openapi_types.UUID, versionId openapi_types.UUID) error {
-	return nil
+func (h *Handler) GetOssVersion(ctx echo.Context, ossId openapi_types.UUID, versionId openapi_types.UUID) error {
+	v, err := h.OssVersionRepo.Get(ctx.Request().Context(), versionId.String())
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "version not found")
+		}
+		return err
+	}
+	res := toOssVersion(*v)
+	return ctx.JSON(http.StatusOK, res)
 }
 
 // バージョン更新
 // (PATCH /oss/{ossId}/versions/{versionId})
-func (*Handler) UpdateOssVersion(ctx echo.Context, ossId openapi_types.UUID, versionId openapi_types.UUID) error {
-	return nil
+func (h *Handler) UpdateOssVersion(ctx echo.Context, ossId openapi_types.UUID, versionId openapi_types.UUID) error {
+	var req gen.OssVersionUpdateRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid body")
+	}
+	v, err := h.OssVersionRepo.Get(ctx.Request().Context(), versionId.String())
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "version not found")
+		}
+		return err
+	}
+	if req.ReleaseDate != nil {
+		t := req.ReleaseDate.Time
+		v.ReleaseDate = &t
+	}
+	if req.LicenseExpressionRaw != nil {
+		v.LicenseExpressionRaw = req.LicenseExpressionRaw
+	}
+	if req.LicenseConcluded != nil {
+		v.LicenseConcluded = req.LicenseConcluded
+	}
+	if req.Purl != nil {
+		v.Purl = req.Purl
+	}
+	if req.CpeList != nil {
+		v.CpeList = *req.CpeList
+	}
+	if req.HashSha256 != nil {
+		v.HashSha256 = req.HashSha256
+	}
+	if req.Modified != nil {
+		v.Modified = *req.Modified
+	}
+	if req.ModificationDescription != nil {
+		v.ModificationDescription = req.ModificationDescription
+	}
+	if req.ReviewStatus != nil {
+		v.ReviewStatus = string(*req.ReviewStatus)
+	}
+	if req.ScopeStatus != nil {
+		v.ScopeStatus = string(*req.ScopeStatus)
+	}
+	if req.SupplierType != nil {
+		val := string(*req.SupplierType)
+		v.SupplierType = &val
+	}
+	if req.ForkOriginUrl != nil {
+		v.ForkOriginURL = req.ForkOriginUrl
+	}
+	v.UpdatedAt = time.Now()
+	if err := h.OssVersionRepo.Update(ctx.Request().Context(), v); err != nil {
+		return err
+	}
+	res := toOssVersion(*v)
+	return ctx.JSON(http.StatusOK, res)
 }

--- a/internal/api/handler/oss_handler_test.go
+++ b/internal/api/handler/oss_handler_test.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+	infrarepo "github.com/ramsesyok/oss-catalog/internal/infra/repository"
+)
+
+func setupEcho(h *Handler) *echo.Echo {
+	e := echo.New()
+	gen.RegisterHandlers(e, h)
+	return e
+}
+
+func TestListOssComponents(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	compRepo := &infrarepo.OssComponentRepository{DB: db}
+	layerRepo := &infrarepo.OssComponentLayerRepository{DB: db}
+	tagRepo := &infrarepo.OssComponentTagRepository{DB: db}
+
+	h := &Handler{OssComponentRepo: compRepo, OssComponentLayerRepo: layerRepo, OssComponentTagRepo: tagRepo}
+	e := setupEcho(h)
+
+	id := uuid.NewString()
+	now := time.Now()
+	countQuery := regexp.QuoteMeta("SELECT COUNT(*) FROM oss_components oc WHERE normalized_name LIKE ?")
+	mock.ExpectQuery(countQuery).WithArgs("%redis%").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	listQuery := regexp.QuoteMeta("SELECT oc.id, oc.name, oc.normalized_name, oc.homepage_url, oc.repository_url, oc.description, oc.primary_language, oc.default_usage_role, oc.deprecated, oc.created_at, oc.updated_at FROM oss_components oc WHERE normalized_name LIKE ? ORDER BY oc.created_at DESC LIMIT ? OFFSET ?")
+	mock.ExpectQuery(listQuery).WithArgs("%redis%", 50, 0).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "normalized_name", "homepage_url", "repository_url", "description", "primary_language", "default_usage_role", "deprecated", "created_at", "updated_at"}).
+			AddRow(id, "Redis", "redis", nil, nil, nil, nil, nil, false, now, now))
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT layer FROM oss_component_layers WHERE oss_id = ? ORDER BY layer")).
+		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"layer"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT tg.id, tg.name, tg.created_at FROM tags tg JOIN oss_component_tags ct ON ct.tag_id = tg.id WHERE ct.oss_id = ? ORDER BY tg.created_at DESC")).
+		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"id", "name", "created_at"}))
+
+	req := httptest.NewRequest(http.MethodGet, "/oss?name=redis", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+	var res gen.PagedResultOssComponent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+	require.NotNil(t, res.Items)
+	require.Len(t, *res.Items, 1)
+}
+
+func TestGetOssVersion_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	verRepo := &infrarepo.OssVersionRepository{DB: db}
+	h := &Handler{OssVersionRepo: verRepo}
+	e := setupEcho(h)
+
+	vid := uuid.New()
+	query := regexp.QuoteMeta("SELECT id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at FROM oss_versions WHERE id = ?")
+	mock.ExpectQuery(query).WithArgs(vid.String()).WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/oss/"+uuid.New().String()+"/versions/"+vid.String(), nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetOssVersion_OK(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	verRepo := &infrarepo.OssVersionRepository{DB: db}
+	h := &Handler{OssVersionRepo: verRepo}
+	e := setupEcho(h)
+
+	vid := uuid.New()
+	oid := uuid.New()
+	now := time.Now()
+	query := regexp.QuoteMeta("SELECT id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at FROM oss_versions WHERE id = ?")
+	mockRows := sqlmock.NewRows([]string{"id", "oss_id", "version", "release_date", "license_expression_raw", "license_concluded", "purl", "cpe_list", "hash_sha256", "modified", "modification_description", "review_status", "last_reviewed_at", "scope_status", "supplier_type", "fork_origin_url", "created_at", "updated_at"}).
+		AddRow(vid.String(), oid.String(), "1.0.0", now, nil, nil, nil, pq.StringArray{}, nil, false, nil, "draft", nil, "IN_SCOPE", nil, nil, now, now)
+	mock.ExpectQuery(query).WithArgs(vid.String()).WillReturnRows(mockRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/oss/"+oid.String()+"/versions/"+vid.String(), nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+	var res gen.OssVersion
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+	require.Equal(t, vid, res.Id)
+}


### PR DESCRIPTION
## Summary
- implement OSS component and version handlers
- add repository fields to Handler
- provide conversions and business logic for listing, creating and managing OSS entities
- add API tests using Echo and sqlmock

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d8190fecc8320a90c8a03aee4b469