### PR TITLE
Implement tag handlers with tests

### DIFF
--- a/internal/api/handler/hanlder.go
+++ b/internal/api/handler/hanlder.go
@@ -13,6 +13,7 @@ type Handler struct {
 	OssComponentRepo      domrepo.OssComponentRepository
 	OssComponentLayerRepo domrepo.OssComponentLayerRepository
 	OssComponentTagRepo   domrepo.OssComponentTagRepository
+	TagRepo               domrepo.TagRepository
 	OssVersionRepo        domrepo.OssVersionRepository
 	ProjectRepo           domrepo.ProjectRepository
 	ProjectUsageRepo      domrepo.ProjectUsageRepository

--- a/internal/api/handler/tags_handler.go
+++ b/internal/api/handler/tags_handler.go
@@ -3,24 +3,56 @@ package handler
 // tags_handler.go - /tags に関するハンドラ処理
 
 import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
 )
+
+func toTag(m model.Tag) gen.Tag {
+	return gen.Tag{Id: uuid.MustParse(m.ID), Name: m.Name, CreatedAt: m.CreatedAt}
+}
 
 // タグ一覧
 // (GET /tags)
-func (*Handler) ListTags(ctx echo.Context) error {
-	return nil
+func (h *Handler) ListTags(ctx echo.Context) error {
+	tags, err := h.TagRepo.List(ctx.Request().Context())
+	if err != nil {
+		return err
+	}
+	res := make([]gen.Tag, len(tags))
+	for i, t := range tags {
+		res[i] = toTag(t)
+	}
+	return ctx.JSON(http.StatusOK, res)
 }
 
 // タグ作成
 // (POST /tags)
-func (*Handler) CreateTag(ctx echo.Context) error {
-	return nil
+func (h *Handler) CreateTag(ctx echo.Context) error {
+	var req gen.TagCreateRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid body")
+	}
+	now := time.Now()
+	tag := &model.Tag{ID: uuid.NewString(), Name: req.Name, CreatedAt: &now}
+	if err := h.TagRepo.Create(ctx.Request().Context(), tag); err != nil {
+		return err
+	}
+	res := toTag(*tag)
+	return ctx.JSON(http.StatusCreated, res)
 }
 
 // タグ削除
 // (DELETE /tags/{tagId})
-func (*Handler) DeleteTag(ctx echo.Context, tagId openapi_types.UUID) error {
-	return nil
+func (h *Handler) DeleteTag(ctx echo.Context, tagId openapi_types.UUID) error {
+	if err := h.TagRepo.Delete(ctx.Request().Context(), tagId.String()); err != nil {
+		return err
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }

--- a/internal/api/handler/tags_handler_test.go
+++ b/internal/api/handler/tags_handler_test.go
@@ -1,0 +1,167 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+	infrarepo "github.com/ramsesyok/oss-catalog/internal/infra/repository"
+)
+
+func TestListTags(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.TagRepository{DB: db}
+	h := &Handler{TagRepo: repo}
+	e := setupEcho(h)
+
+	now := time.Now()
+	query := regexp.QuoteMeta(`SELECT id, name, created_at FROM tags ORDER BY created_at DESC`)
+	mock.ExpectQuery(query).WillReturnRows(sqlmock.NewRows([]string{"id", "name", "created_at"}).AddRow(uuid.NewString(), "db", now))
+
+	req := httptest.NewRequest(http.MethodGet, "/tags", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+	var res []gen.Tag
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+	require.Len(t, res, 1)
+}
+
+func TestListTags_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.TagRepository{DB: db}
+	h := &Handler{TagRepo: repo}
+	e := setupEcho(h)
+
+	query := regexp.QuoteMeta(`SELECT id, name, created_at FROM tags ORDER BY created_at DESC`)
+	mock.ExpectQuery(query).WillReturnError(sqlmock.ErrCancelled)
+
+	req := httptest.NewRequest(http.MethodGet, "/tags", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateTag(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.TagRepository{DB: db}
+	h := &Handler{TagRepo: repo}
+	e := setupEcho(h)
+
+	body := `{"name":"db"}`
+	query := regexp.QuoteMeta(`INSERT INTO tags (id, name, created_at) VALUES (?, ?, ?)`)
+	mock.ExpectExec(query).WithArgs(sqlmock.AnyArg(), "db", sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/tags", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateTag_InvalidBody(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.TagRepository{DB: db}
+	h := &Handler{TagRepo: repo}
+	e := setupEcho(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/tags", strings.NewReader("{"))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateTag_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.TagRepository{DB: db}
+	h := &Handler{TagRepo: repo}
+	e := setupEcho(h)
+
+	body := `{"name":"db"}`
+	query := regexp.QuoteMeta(`INSERT INTO tags (id, name, created_at) VALUES (?, ?, ?)`)
+	mock.ExpectExec(query).WillReturnError(sqlmock.ErrCancelled)
+
+	req := httptest.NewRequest(http.MethodPost, "/tags", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeleteTag(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.TagRepository{DB: db}
+	h := &Handler{TagRepo: repo}
+	e := setupEcho(h)
+
+	id := uuid.NewString()
+	query := regexp.QuoteMeta(`DELETE FROM tags WHERE id = ?`)
+	mock.ExpectExec(query).WithArgs(id).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req := httptest.NewRequest(http.MethodDelete, "/tags/"+id, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeleteTag_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.TagRepository{DB: db}
+	h := &Handler{TagRepo: repo}
+	e := setupEcho(h)
+
+	id := uuid.NewString()
+	query := regexp.QuoteMeta(`DELETE FROM tags WHERE id = ?`)
+	mock.ExpectExec(query).WithArgs(id).WillReturnError(sqlmock.ErrCancelled)
+
+	req := httptest.NewRequest(http.MethodDelete, "/tags/"+id, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
- add TagRepo to Handler
- implement tag CRUD handlers
- add extensive tests for tag handlers

## Testing
- `go vet ./...`
- `go test -coverprofile=full.out ./internal/api/handler/...`
- `go tool cover -func=full.out | grep -E 'tags_handler.go'`

------
https://chatgpt.com/codex/tasks/task_e_687d8ed436d4832098b3f23512d4558d