### PR TITLE
Add Windows service capability

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,9 +2,10 @@
 package main
 
 import (
-	//...
+	"flag"
 	"log"
 	"net"
+	"runtime"
 
 	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
 	"github.com/ramsesyok/oss-catalog/internal/api/handler"
@@ -14,21 +15,55 @@ import (
 	middleware "github.com/oapi-codegen/echo-middleware"
 )
 
-func main() {
+const serviceName = "oss-catalog"
+
+func runServer() error {
 	// OASテンプレートの読み込み
 	swagger, err := gen.GetSwagger()
 	if err != nil {
-		log.Fatalf("Error loading OAS template: %s", err)
+		return err
 	}
 	// ホスト名での検証は行わない
 	swagger.Servers = nil
 
-	handler := handler.Handler{}
+	h := handler.Handler{}
 
 	e := echo.New()
 	e.Use(echomiddleware.Logger())
 	// OASテンプレートで指定したスキーマによる検証を行う
 	e.Use(middleware.OapiRequestValidator(swagger))
-	gen.RegisterHandlers(e, &handler)
-	e.Logger.Fatal(e.Start(net.JoinHostPort("0.0.0.0", "8080")))
+	gen.RegisterHandlers(e, &h)
+	return e.Start(net.JoinHostPort("0.0.0.0", "8080"))
+}
+
+func main() {
+	svcFlag := flag.String("service", "", "windows service control (install|uninstall)")
+	flag.Parse()
+
+	if runtime.GOOS == "windows" {
+		switch *svcFlag {
+		case "install":
+			if err := installService(serviceName, "OSS Catalog service"); err != nil {
+				log.Fatalf("install failed: %v", err)
+			}
+			return
+		case "uninstall":
+			if err := removeService(serviceName); err != nil {
+				log.Fatalf("uninstall failed: %v", err)
+			}
+			return
+		}
+
+		isSvc, err := isWindowsService()
+		if err == nil && isSvc {
+			if err := runService(serviceName); err != nil {
+				log.Fatalf("service run failed: %v", err)
+			}
+			return
+		}
+	}
+
+	if err := runServer(); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
 }

--- a/winservice_stub.go
+++ b/winservice_stub.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+import "errors"
+
+var errUnsupported = errors.New("windows service not supported")
+
+func isWindowsService() (bool, error)        { return false, errUnsupported }
+func runService(name string) error           { return errUnsupported }
+func installService(name, desc string) error { return errUnsupported }
+func removeService(name string) error        { return errUnsupported }

--- a/winservice_windows.go
+++ b/winservice_windows.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// isWindowsService returns true if running under the Windows service manager.
+func isWindowsService() (bool, error) {
+	return svc.IsWindowsService()
+}
+
+type service struct{}
+
+func (m *service) Execute(args []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
+	const accepted = svc.AcceptStop | svc.AcceptShutdown
+	s <- svc.Status{State: svc.StartPending}
+	go func() {
+		if err := runServer(); err != nil {
+			log.Printf("server error: %v", err)
+		}
+	}()
+	s <- svc.Status{State: svc.Running, Accepts: accepted}
+	for {
+		c := <-r
+		switch c.Cmd {
+		case svc.Interrogate:
+			s <- c.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			s <- svc.Status{State: svc.StopPending}
+			return false, 0
+		default:
+		}
+	}
+}
+
+func runService(name string) error {
+	return svc.Run(name, &service{})
+}
+
+func installService(name, desc string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	m, err := mgr.Connect()
+	if err != nil {
+		return err
+	}
+	defer m.Disconnect()
+	s, err := m.OpenService(name)
+	if err == nil {
+		s.Close()
+		return nil
+	}
+	s, err = m.CreateService(name, exe, mgr.Config{DisplayName: name, Description: desc})
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	return nil
+}
+
+func removeService(name string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return err
+	}
+	defer m.Disconnect()
+	s, err := m.OpenService(name)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	return s.Delete()
+}


### PR DESCRIPTION
## Summary
- add server run function and service flag handling
- implement Windows service helpers with `golang.org/x/sys/windows/svc`
- provide stub implementations for non-Windows builds

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687dcc95566c83209d2e08040aef79cd