### PR TITLE
Add migrations for users table

### DIFF
--- a/internal/api/handler/users_handler.go
+++ b/internal/api/handler/users_handler.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+)
+
+// ---- Users ----
+
+// ListUsers ユーザー一覧 (GET /users)
+func (*Handler) ListUsers(ctx echo.Context, params gen.ListUsersParams) error {
+	return ctx.JSON(http.StatusOK, map[string]any{"placeholder": "todo"})
+}
+
+// CreateUser ユーザー作成 (POST /users)
+func (*Handler) CreateUser(ctx echo.Context) error {
+	return ctx.JSON(http.StatusCreated, map[string]any{"placeholder": "todo"})
+}
+
+// GetUser ユーザー詳細 (GET /users/{userId})
+func (*Handler) GetUser(ctx echo.Context, userId openapi_types.UUID) error {
+	return ctx.JSON(http.StatusOK, map[string]any{"placeholder": "todo"})
+}
+
+// UpdateUser ユーザー更新 (PATCH /users/{userId})
+func (*Handler) UpdateUser(ctx echo.Context, userId openapi_types.UUID) error {
+	return ctx.JSON(http.StatusOK, map[string]any{"placeholder": "todo"})
+}
+
+// DeleteUser ユーザー削除 (DELETE /users/{userId})
+func (*Handler) DeleteUser(ctx echo.Context, userId openapi_types.UUID) error {
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// GetCurrentUser 現在ログイン中ユーザー取得 (GET /me)
+func (*Handler) GetCurrentUser(ctx echo.Context) error {
+	return ctx.JSON(http.StatusOK, map[string]any{"placeholder": "todo"})
+}

--- a/migrations/0002_create_users.down.sql
+++ b/migrations/0002_create_users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/migrations/0002_create_users.up.sql
+++ b/migrations/0002_create_users.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    username TEXT NOT NULL UNIQUE,
+    display_name TEXT,
+    email TEXT,
+    password_hash TEXT NOT NULL,
+    roles TEXT[] NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- regenerate code from updated OpenAPI spec
- add stub user handlers to satisfy compile
- add migrations for `users` table

## Testing
- `go vet ./...`
- `go test ./...`
- `go generate ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884047173948320a3e022c8106e0987