### PR TITLE
Implement JWT auth middleware and helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/getkin/kin-openapi v0.132.0
+	github.com/golang-jwt/jwt/v5 v5.2.3
 	github.com/google/uuid v1.6.0
+	github.com/labstack/echo-jwt/v4 v4.3.1
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang-jwt/jwt/v5 v5.2.3 h1:kkGXqQOBSDDWRhWNXTFpqGSCMyh/PLnqUvMGJPDJDs0=
+github.com/golang-jwt/jwt/v5 v5.2.3/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -56,6 +58,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/labstack/echo-jwt/v4 v4.3.1 h1:d8+/qf8nx7RxeL46LtoIwHJsH2PNN8xXCQ/jDianycE=
+github.com/labstack/echo-jwt/v4 v4.3.1/go.mod h1:yJi83kN8S/5vePVPd+7ID75P4PqPNVRs2HVeuvYJH00=
 github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcXEA=
 github.com/labstack/echo/v4 v4.13.4/go.mod h1:g63b33BZ5vZzcIUF8AtRH40DrTlXnx4UMC8rBdndmjQ=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=

--- a/internal/api/handler/auth_handler.go
+++ b/internal/api/handler/auth_handler.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+	"github.com/ramsesyok/oss-catalog/pkg/auth"
+	problem "github.com/ramsesyok/oss-catalog/pkg/response"
+)
+
+// Login issues JWT token.
+func (h *Handler) Login(ctx echo.Context) error {
+	var req gen.LoginJSONBody
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid body")
+	}
+	users, _, err := h.UserRepo.Search(ctx.Request().Context(), domrepo.UserFilter{Username: req.Username, Page: 1, Size: 1})
+	if err != nil {
+		return err
+	}
+	if len(users) == 0 || users[0].PasswordHash != req.Password {
+		return problem.Unauthorized(ctx, "INVALID_CREDENTIAL", "invalid username or password")
+	}
+	token, exp, err := auth.GenerateToken(&users[0])
+	if err != nil {
+		return err
+	}
+	res := gen.LoginResponse{AccessToken: token, ExpiresIn: exp}
+	return ctx.JSON(http.StatusOK, res)
+}
+
+// Logout is a no-op placeholder.
+func (h *Handler) Logout(ctx echo.Context) error {
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// GetCurrentUser returns current user info based on JWT claims.
+func (h *Handler) GetCurrentUser(ctx echo.Context) error {
+	claims := auth.GetClaims(ctx)
+	if claims == nil {
+		return problem.Unauthorized(ctx, "UNAUTHORIZED", "no claims")
+	}
+	u, err := h.UserRepo.Get(ctx.Request().Context(), claims.Sub)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "user not found")
+		}
+		return err
+	}
+	res := toUser(*u)
+	return ctx.JSON(http.StatusOK, res)
+}

--- a/internal/api/handler/auth_handler_test.go
+++ b/internal/api/handler/auth_handler_test.go
@@ -1,0 +1,126 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	apirouter "github.com/ramsesyok/oss-catalog/internal/api"
+	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+	handler "github.com/ramsesyok/oss-catalog/internal/api/handler"
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	infrarepo "github.com/ramsesyok/oss-catalog/internal/infra/repository"
+	"github.com/ramsesyok/oss-catalog/pkg/auth"
+)
+
+func setupAuthEcho(h *handler.Handler) (*echo.Echo, string) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	os.Setenv("JWT_EXPIRES_MIN", "1")
+	e := echo.New()
+	apirouter.RegisterRoutes(e, h)
+	u := &model.User{ID: uuid.NewString(), Username: "admin", PasswordHash: "pass", Roles: []string{"ADMIN"}, Active: true}
+	token, _, _ := auth.GenerateToken(u)
+	return e, token
+}
+
+func TestLoginAndAccess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.UserRepository{DB: db}
+	h := &handler.Handler{UserRepo: repo}
+	e, _ := setupAuthEcho(h)
+
+	now := time.Now()
+	uid := uuid.NewString()
+	countQuery := regexp.QuoteMeta("SELECT COUNT(*) FROM users WHERE username LIKE ?")
+	mock.ExpectQuery(countQuery).WithArgs("%admin%").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	listQuery := regexp.QuoteMeta("SELECT id, username, display_name, email, password_hash, roles, active, created_at, updated_at FROM users WHERE username LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?")
+	mock.ExpectQuery(listQuery).WithArgs("%admin%", 1, 0).WillReturnRows(
+		sqlmock.NewRows([]string{"id", "username", "display_name", "email", "password_hash", "roles", "active", "created_at", "updated_at"}).
+			AddRow(uid, "admin", nil, nil, "pass", pq.StringArray{"ADMIN"}, true, now, now),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", strings.NewReader(`{"username":"admin","password":"pass"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var res gen.LoginResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+	require.NotEmpty(t, res.AccessToken)
+	t.Logf("token=%s", res.AccessToken)
+
+	// expectation for GetCurrentUser
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, username, display_name, email, password_hash, roles, active, created_at, updated_at FROM users WHERE id = ?")).
+		WithArgs(uid).WillReturnRows(
+		sqlmock.NewRows([]string{"id", "username", "display_name", "email", "password_hash", "roles", "active", "created_at", "updated_at"}).
+			AddRow(uid, "admin", nil, nil, "pass", pq.StringArray{"ADMIN"}, true, now, now),
+	)
+	req2 := httptest.NewRequest(http.MethodGet, "/me", nil)
+	req2.Header.Set("Authorization", "Bearer "+res.AccessToken)
+	rec2 := httptest.NewRecorder()
+	e.ServeHTTP(rec2, req2)
+	t.Logf("me body=%s", rec2.Body.String())
+	require.Equal(t, http.StatusOK, rec2.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRolesRequired_Forbidden(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &infrarepo.UserRepository{DB: db}
+	h := &handler.Handler{UserRepo: repo}
+	e, token := setupAuthEcho(h)
+
+	e.GET("/admin", func(c echo.Context) error { return c.String(200, "ok") }, auth.RolesRequired("ADMIN"))
+
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	// token for admin already generated but we need viewer role token to test deny
+	viewer := &model.User{ID: uuid.NewString(), Username: "view", PasswordHash: "pass", Roles: []string{"VIEWER"}, Active: true}
+	vtoken, _, _ := auth.GenerateToken(viewer)
+	req.Header.Set("Authorization", "Bearer "+vtoken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+	_ = token // silence unused
+}
+
+func TestExpiredToken(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	repo := &infrarepo.UserRepository{DB: db}
+	h := &handler.Handler{UserRepo: repo}
+	os.Setenv("JWT_SECRET", "testsecret")
+	os.Setenv("JWT_EXPIRES_MIN", "-1")
+	e := echo.New()
+	apirouter.RegisterRoutes(e, h)
+
+	expiredUser := &model.User{ID: uuid.NewString(), Username: "a", PasswordHash: "p", Roles: []string{"ADMIN"}, Active: true}
+	token, _, _ := auth.GenerateToken(expiredUser)
+
+	req := httptest.NewRequest(http.MethodGet, "/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	t.Logf("expired body=%s status=%d", rec.Body.String(), rec.Code)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/api/handler/users_handler.go
+++ b/internal/api/handler/users_handler.go
@@ -175,8 +175,3 @@ func (h *Handler) DeleteUser(ctx echo.Context, userId openapi_types.UUID) error 
 	}
 	return ctx.NoContent(http.StatusNoContent)
 }
-
-// GetCurrentUser 現在ログイン中ユーザー取得 (GET /me)
-func (h *Handler) GetCurrentUser(ctx echo.Context) error {
-	return ctx.JSON(http.StatusOK, map[string]any{"placeholder": "todo"})
-}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"github.com/golang-jwt/jwt/v5"
+	echojwt "github.com/labstack/echo-jwt/v4"
+	"github.com/labstack/echo/v4"
+	"github.com/ramsesyok/oss-catalog/internal/api/gen"
+	"github.com/ramsesyok/oss-catalog/internal/api/handler"
+	"github.com/ramsesyok/oss-catalog/pkg/auth"
+	problem "github.com/ramsesyok/oss-catalog/pkg/response"
+	"os"
+)
+
+// RegisterRoutes registers handlers with JWT auth.
+func RegisterRoutes(e *echo.Echo, h *handler.Handler) {
+	cfg := echojwt.Config{
+		SigningKey:    []byte(os.Getenv("JWT_SECRET")),
+		ContextKey:    "authUser",
+		NewClaimsFunc: func(c echo.Context) jwt.Claims { return &auth.Claims{} },
+		ErrorHandler: func(c echo.Context, err error) error {
+			return problem.Unauthorized(c, "UNAUTHORIZED", "token invalid or expired")
+		},
+	}
+	authRequired := echojwt.WithConfig(cfg)
+
+	wrapper := gen.ServerInterfaceWrapper{Handler: h}
+
+	e.POST("/auth/login", wrapper.Login)
+	e.POST("/auth/logout", wrapper.Logout, authRequired)
+
+	g := e.Group("", authRequired)
+	g.GET("/audit", wrapper.SearchAuditLogs)
+	g.GET("/me", wrapper.GetCurrentUser)
+	g.GET("/oss", wrapper.ListOssComponents)
+	g.POST("/oss", wrapper.CreateOssComponent)
+	g.DELETE("/oss/:ossId", wrapper.DeprecateOssComponent)
+	g.GET("/oss/:ossId", wrapper.GetOssComponent)
+	g.PATCH("/oss/:ossId", wrapper.UpdateOssComponent)
+	g.GET("/oss/:ossId/versions", wrapper.ListOssVersions)
+	g.POST("/oss/:ossId/versions", wrapper.CreateOssVersion)
+	g.DELETE("/oss/:ossId/versions/:versionId", wrapper.DeleteOssVersion)
+	g.GET("/oss/:ossId/versions/:versionId", wrapper.GetOssVersion)
+	g.PATCH("/oss/:ossId/versions/:versionId", wrapper.UpdateOssVersion)
+	g.GET("/projects", wrapper.ListProjects)
+	g.POST("/projects", wrapper.CreateProject)
+	g.DELETE("/projects/:projectId", wrapper.DeleteProject)
+	g.GET("/projects/:projectId", wrapper.GetProject)
+	g.PATCH("/projects/:projectId", wrapper.UpdateProject)
+	g.GET("/projects/:projectId/export", wrapper.ExportProjectArtifacts)
+	g.GET("/projects/:projectId/usages", wrapper.ListProjectUsages)
+	g.POST("/projects/:projectId/usages", wrapper.CreateProjectUsage)
+	g.DELETE("/projects/:projectId/usages/:usageId", wrapper.DeleteProjectUsage)
+	g.PATCH("/projects/:projectId/usages/:usageId", wrapper.UpdateProjectUsage)
+	g.PATCH("/projects/:projectId/usages/:usageId/scope", wrapper.UpdateProjectUsageScope)
+	g.GET("/scope/policy", wrapper.GetScopePolicy)
+	g.PATCH("/scope/policy", wrapper.UpdateScopePolicy)
+	g.GET("/tags", wrapper.ListTags)
+	g.POST("/tags", wrapper.CreateTag)
+	g.DELETE("/tags/:tagId", wrapper.DeleteTag)
+	g.GET("/users", wrapper.ListUsers)
+	g.POST("/users", wrapper.CreateUser)
+	g.DELETE("/users/:userId", wrapper.DeleteUser)
+	g.GET("/users/:userId", wrapper.GetUser)
+	g.PATCH("/users/:userId", wrapper.UpdateUser)
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"runtime"
 
+	apirouter "github.com/ramsesyok/oss-catalog/internal/api"
 	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
 	"github.com/ramsesyok/oss-catalog/internal/api/handler"
 	"github.com/ramsesyok/oss-catalog/internal/config"
@@ -36,7 +37,7 @@ func runServer(host, port string, origins []string) error {
 	}))
 	// OASテンプレートで指定したスキーマによる検証を行う
 	e.Use(middleware.OapiRequestValidator(swagger))
-	gen.RegisterHandlers(e, &h)
+	apirouter.RegisterRoutes(e, &h)
 	return e.Start(net.JoinHostPort(host, port))
 }
 

--- a/pkg/auth/claims.go
+++ b/pkg/auth/claims.go
@@ -1,0 +1,11 @@
+package auth
+
+import "github.com/golang-jwt/jwt/v5"
+
+// Claims defines JWT claims for access tokens.
+type Claims struct {
+	Sub      string   `json:"sub"`
+	Username string   `json:"username"`
+	Roles    []string `json:"roles"`
+	jwt.RegisteredClaims
+}

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// GetClaims retrieves JWT claims from echo context.
+func GetClaims(c echo.Context) *Claims {
+	v := c.Get("authUser")
+	if token, ok := v.(*jwt.Token); ok {
+		if cl, ok := token.Claims.(*Claims); ok {
+			return cl
+		}
+	}
+	return nil
+}

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+)
+
+// GenerateToken generates a signed JWT for the given user.
+// It returns the token string and expiresIn seconds.
+func GenerateToken(u *model.User) (string, int, error) {
+	expMin := 15
+	if s := os.Getenv("JWT_EXPIRES_MIN"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil {
+			expMin = v
+		}
+	}
+	now := time.Now()
+	claims := Claims{
+		Sub:      u.ID,
+		Username: u.Username,
+		Roles:    u.Roles,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Duration(expMin) * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(os.Getenv("JWT_SECRET")))
+	if err != nil {
+		return "", 0, err
+	}
+	return signed, expMin * 60, nil
+}

--- a/pkg/auth/roles.go
+++ b/pkg/auth/roles.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"github.com/labstack/echo/v4"
+	problem "github.com/ramsesyok/oss-catalog/pkg/response"
+)
+
+// RolesRequired ensures the user has at least one of the allowed roles.
+func RolesRequired(allowed ...string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			claims := GetClaims(c)
+			if claims == nil {
+				return problem.Forbidden(c, "RBAC_DENY", "missing claims")
+			}
+			for _, r := range claims.Roles {
+				for _, a := range allowed {
+					if r == a {
+						return next(c)
+					}
+				}
+			}
+			return problem.Forbidden(c, "RBAC_DENY", "role not allowed")
+		}
+	}
+}

--- a/pkg/response/problem.go
+++ b/pkg/response/problem.go
@@ -1,0 +1,29 @@
+package problem
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	gen "github.com/ramsesyok/oss-catalog/internal/api/gen"
+)
+
+func respond(c echo.Context, status int, title, code, detail string) error {
+	p := gen.Problem{Title: title, Status: status}
+	if code != "" {
+		p.Code = &code
+	}
+	if detail != "" {
+		p.Detail = &detail
+	}
+	return c.JSON(status, p)
+}
+
+// Unauthorized returns 401 Problem JSON.
+func Unauthorized(c echo.Context, code, detail string) error {
+	return respond(c, http.StatusUnauthorized, "UNAUTHORIZED", code, detail)
+}
+
+// Forbidden returns 403 Problem JSON.
+func Forbidden(c echo.Context, code, detail string) error {
+	return respond(c, http.StatusForbidden, "FORBIDDEN", code, detail)
+}


### PR DESCRIPTION
## Summary
- update dependencies for JWT auth
- generate updated API code
- implement JWT token generator and context helpers
- add problem response utilities
- add router setup with jwt middleware
- implement auth handlers and RBAC middleware
- add unit tests for login and authorization
- fix token expiration parsing for tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884365d9ef083208ee3e66afc2e8bcf