### PR TITLE
Implement JWT login/logout

### DIFF
--- a/internal/domain/repository/user_repository.go
+++ b/internal/domain/repository/user_repository.go
@@ -18,6 +18,8 @@ type UserFilter struct {
 type UserRepository interface {
 	Search(ctx context.Context, f UserFilter) ([]model.User, int, error)
 	Get(ctx context.Context, id string) (*model.User, error)
+	// FindByUsername returns a user for exact username match.
+	FindByUsername(ctx context.Context, username string) (*model.User, error)
 	Create(ctx context.Context, u *model.User) error
 	Update(ctx context.Context, u *model.User) error
 	Delete(ctx context.Context, id string) error

--- a/internal/domain/service/auth.go
+++ b/internal/domain/service/auth.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+	"github.com/ramsesyok/oss-catalog/pkg/auth"
+)
+
+var (
+	ErrInvalidCredential = errors.New("invalid credential")
+	ErrUserDisabled      = errors.New("user disabled")
+)
+
+// AuthService handles authentication logic.
+type AuthService struct {
+	UserRepo domrepo.UserRepository
+}
+
+// Authenticate verifies username and password and returns user if valid.
+func (s *AuthService) Authenticate(ctx context.Context, username, password string) (*model.User, error) {
+	u, err := s.UserRepo.FindByUsername(ctx, username)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrInvalidCredential
+		}
+		return nil, err
+	}
+	if !u.Active {
+		return nil, ErrUserDisabled
+	}
+	if err := auth.Compare(u.PasswordHash, password); err != nil {
+		return nil, ErrInvalidCredential
+	}
+	return u, nil
+}

--- a/internal/domain/service/auth_test.go
+++ b/internal/domain/service/auth_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
+	"github.com/ramsesyok/oss-catalog/pkg/auth"
+)
+
+type stubUserRepo struct {
+	user *model.User
+	err  error
+}
+
+func (s *stubUserRepo) Search(ctx context.Context, f domrepo.UserFilter) ([]model.User, int, error) {
+	return nil, 0, nil
+}
+func (s *stubUserRepo) Get(ctx context.Context, id string) (*model.User, error) { return nil, nil }
+func (s *stubUserRepo) Create(ctx context.Context, u *model.User) error         { return nil }
+func (s *stubUserRepo) Update(ctx context.Context, u *model.User) error         { return nil }
+func (s *stubUserRepo) Delete(ctx context.Context, id string) error             { return nil }
+func (s *stubUserRepo) FindByUsername(ctx context.Context, username string) (*model.User, error) {
+	return s.user, s.err
+}
+
+func TestAuthenticate_Success(t *testing.T) {
+	hash, _ := auth.Hash("pass")
+	repo := &stubUserRepo{user: &model.User{ID: uuid.NewString(), Username: "a", PasswordHash: hash, Active: true}}
+	svc := AuthService{UserRepo: repo}
+	u, err := svc.Authenticate(context.Background(), "a", "pass")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u == nil || u.Username != "a" {
+		t.Fatalf("unexpected user: %#v", u)
+	}
+}
+
+func TestAuthenticate_UserDisabled(t *testing.T) {
+	hash, _ := auth.Hash("pass")
+	repo := &stubUserRepo{user: &model.User{ID: uuid.NewString(), Username: "a", PasswordHash: hash, Active: false}}
+	svc := AuthService{UserRepo: repo}
+	_, err := svc.Authenticate(context.Background(), "a", "pass")
+	if err != ErrUserDisabled {
+		t.Fatalf("expected ErrUserDisabled, got %v", err)
+	}
+}
+
+func TestAuthenticate_InvalidPassword(t *testing.T) {
+	hash, _ := auth.Hash("pass")
+	repo := &stubUserRepo{user: &model.User{ID: uuid.NewString(), Username: "a", PasswordHash: hash, Active: true}}
+	svc := AuthService{UserRepo: repo}
+	_, err := svc.Authenticate(context.Background(), "a", "wrong")
+	if err != ErrInvalidCredential {
+		t.Fatalf("expected ErrInvalidCredential, got %v", err)
+	}
+}
+
+func TestAuthenticate_NotFound(t *testing.T) {
+	repo := &stubUserRepo{err: sql.ErrNoRows}
+	svc := AuthService{UserRepo: repo}
+	_, err := svc.Authenticate(context.Background(), "a", "p")
+	if err != ErrInvalidCredential {
+		t.Fatalf("expected ErrInvalidCredential, got %v", err)
+	}
+}

--- a/internal/infra/repository/user_repository.go
+++ b/internal/infra/repository/user_repository.go
@@ -79,6 +79,21 @@ func (r *UserRepository) Get(ctx context.Context, id string) (*model.User, error
 	return &u, nil
 }
 
+// FindByUsername returns a user by username.
+func (r *UserRepository) FindByUsername(ctx context.Context, username string) (*model.User, error) {
+	row := r.DB.QueryRowContext(ctx, `SELECT id, username, display_name, email, password_hash, roles, active, created_at, updated_at FROM users WHERE username = ?`, username)
+	var u model.User
+	var display, email sql.NullString
+	var roles pq.StringArray
+	if err := row.Scan(&u.ID, &u.Username, &display, &email, &u.PasswordHash, &roles, &u.Active, &u.CreatedAt, &u.UpdatedAt); err != nil {
+		return nil, err
+	}
+	u.DisplayName = strPtr(display)
+	u.Email = strPtr(email)
+	u.Roles = []string(roles)
+	return &u, nil
+}
+
 // Create は新しいユーザーを登録する。
 func (r *UserRepository) Create(ctx context.Context, u *model.User) error {
 	_, err := r.DB.ExecContext(ctx,

--- a/internal/infra/repository/user_repository_test.go
+++ b/internal/infra/repository/user_repository_test.go
@@ -59,6 +59,28 @@ func TestUserRepository_Get(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestUserRepository_FindByUsername(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := &UserRepository{DB: db}
+
+	username := "admin"
+	query := regexp.QuoteMeta("SELECT id, username, display_name, email, password_hash, roles, active, created_at, updated_at FROM users WHERE username = ?")
+	now := time.Now()
+	id := uuid.NewString()
+	mock.ExpectQuery(query).WithArgs(username).WillReturnRows(
+		sqlmock.NewRows([]string{"id", "username", "display_name", "email", "password_hash", "roles", "active", "created_at", "updated_at"}).
+			AddRow(id, username, nil, nil, "hash", pq.StringArray{"ADMIN"}, true, now, now),
+	)
+
+	u, err := repo.FindByUsername(context.Background(), username)
+	require.NoError(t, err)
+	require.Equal(t, username, u.Username)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestUserRepository_Create(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/pkg/auth/password.go
+++ b/pkg/auth/password.go
@@ -1,0 +1,17 @@
+package auth
+
+import "golang.org/x/crypto/bcrypt"
+
+// Hash generates bcrypt hash of the password using DefaultCost.
+func Hash(password string) (string, error) {
+	b, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// Compare compares hashed password with plain password.
+func Compare(hash, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+}

--- a/pkg/auth/password_test.go
+++ b/pkg/auth/password_test.go
@@ -1,0 +1,16 @@
+package auth
+
+import "testing"
+
+func TestHashAndCompare(t *testing.T) {
+	hash, err := Hash("pass")
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
+	if err := Compare(hash, "pass"); err != nil {
+		t.Fatalf("compare error: %v", err)
+	}
+	if err := Compare(hash, "wrong"); err == nil {
+		t.Fatalf("expected error on wrong password")
+	}
+}


### PR DESCRIPTION
## Summary
- add bcrypt helpers for password hashing and comparison
- implement AuthService and use it in Login handler
- support logout endpoint (placeholder)
- add repository method to find user by username
- adjust tests for authentication

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68843f61ed00832091c7adc7c8ee7d84