### PR TITLE
Add admin user creation on migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ go.work.sum
 # env file
 .env
 
+# generated admin password
+admin.initial.password
+
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/internal/infra/migration/migration.go
+++ b/internal/infra/migration/migration.go
@@ -1,16 +1,26 @@
 package migration
 
 import (
+	"context"
+	"crypto/rand"
 	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/google/uuid"
 
+	"github.com/ramsesyok/oss-catalog/internal/domain/model"
+	"github.com/ramsesyok/oss-catalog/internal/infra/repository"
 	"github.com/ramsesyok/oss-catalog/migrations"
+	"github.com/ramsesyok/oss-catalog/pkg/auth"
 )
 
 // Apply runs all up migrations using golang-migrate. If the schema is already up to date,
@@ -42,5 +52,70 @@ func Apply(db *sql.DB, dsn string) error {
 	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
 		return err
 	}
+
+	pass, err := ensureAdminUser(db)
+	if err != nil {
+		return err
+	}
+	if pass != "" {
+		if err := savePasswordFile(pass); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func ensureAdminUser(db *sql.DB) (string, error) {
+	repo := &repository.UserRepository{DB: db}
+	ctx := context.Background()
+	if _, err := repo.FindByUsername(ctx, "admin"); err == nil {
+		return "", nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+
+	pass := randomString(16)
+	hash, err := auth.Hash(pass)
+	if err != nil {
+		return "", err
+	}
+	now := time.Now()
+	u := &model.User{
+		ID:           uuid.NewString(),
+		Username:     "admin",
+		PasswordHash: hash,
+		Roles:        []string{"ADMIN"},
+		Active:       true,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := repo.Create(ctx, u); err != nil {
+		return "", err
+	}
+	return pass, nil
+}
+
+func randomString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		for i := range b {
+			b[i] = letters[int(time.Now().UnixNano())%len(letters)]
+		}
+		return string(b)
+	}
+	for i := range b {
+		b[i] = letters[int(b[i])%len(letters)]
+	}
+	return string(b)
+}
+
+func savePasswordFile(pass string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(exe)
+	path := filepath.Join(dir, "admin.initial.password")
+	return os.WriteFile(path, []byte(pass), 0600)
 }

--- a/internal/infra/migration/migration_test.go
+++ b/internal/infra/migration/migration_test.go
@@ -2,6 +2,8 @@ package migration
 
 import (
 	"database/sql"
+	"os"
+	"path/filepath"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -20,4 +22,17 @@ func TestApply_SQLite(t *testing.T) {
 	err = db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name='tags'`).Scan(&name)
 	require.NoError(t, err)
 	require.Equal(t, "tags", name)
+
+	var cnt int
+	err = db.QueryRow(`SELECT COUNT(*) FROM users WHERE username = 'admin'`).Scan(&cnt)
+	require.NoError(t, err)
+	require.Equal(t, 1, cnt)
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	p := filepath.Join(filepath.Dir(exe), "admin.initial.password")
+	data, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+	os.Remove(p)
 }


### PR DESCRIPTION
## Summary
- create admin user automatically during migration
- generate random password, save to `admin.initial.password`
- test admin user creation
- ignore generated password file

## Testing
- `go vet ./...`
- `go test ./...`
- `go generate ./...`

------
https://chatgpt.com/codex/tasks/task_e_6884d564b0d88320ab25cde2662ae6ba