### PR TITLE
Add tavern API test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,11 @@ jobs:
         run: go vet ./...
       - name: Test
         run: go test ./...
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install python deps
+        run: pip install -r requirements.txt
+      - name: API tests
+        run: pytest -vv tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ admin.initial.password
 .vscode/
 .venv
 oss-catalog.db
+oss-catalog-test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+tavern[pytest]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BINARY = REPO_ROOT / "oss-catalog-test"
+
+@pytest.fixture(scope="session", autouse=True)
+def server():
+    # build binary
+    subprocess.run(["go", "build", "-o", str(BINARY), "."], cwd=REPO_ROOT, check=True)
+    proc = subprocess.Popen([str(BINARY)], cwd=REPO_ROOT)
+    passwd_file = REPO_ROOT / "admin.initial.password"
+    # wait for password file
+    for _ in range(30):
+        if passwd_file.exists():
+            break
+        time.sleep(1)
+    else:
+        proc.terminate()
+        pytest.fail("server did not start")
+    password = passwd_file.read_text().strip()
+    base_url = "http://127.0.0.1:8080"
+    os.environ["BASE_URL"] = base_url
+    os.environ["ADMIN_PASSWORD"] = password
+    yield base_url, password
+    proc.terminate()
+    proc.wait()
+    if BINARY.exists():
+        BINARY.unlink()
+    if passwd_file.exists():
+        passwd_file.unlink()
+
+@pytest.fixture(scope="session", autouse=True)
+def token(server):
+    base_url, password = server
+    res = requests.post(f"{base_url}/auth/login", json={"username": "admin", "password": password})
+    res.raise_for_status()
+    tok = res.json()["accessToken"]
+    os.environ["TOKEN"] = tok
+    return tok
+
+@pytest.fixture(scope="session")
+def base_url(server):
+    return server[0]
+
+@pytest.fixture(scope="session")
+def admin_password(server):
+    return server[1]

--- a/tests/test_oss.tavern.yaml
+++ b/tests/test_oss.tavern.yaml
@@ -1,0 +1,16 @@
+test_name: "list oss"
+
+stages:
+  - name: get list
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss"
+      method: GET
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+    response:
+      status_code: 200
+      json:
+        page: 1
+        size: 50
+        total: 0
+        items: []


### PR DESCRIPTION
## Summary
- add pytest requirements and new API test using Tavern
- run tavern tests in CI workflow

## Testing
- `go test ./internal/api/handler -count=1 -v`
- `go test ./pkg/auth -v`
- `pytest -vv -s tests/test_oss.tavern.yaml` *(fails: server build issues)*

------
https://chatgpt.com/codex/tasks/task_e_688d3dd8cfa4832088d1594b56379e8c