### PR TITLE
Introduce DBTime type for DB timestamp parsing

### DIFF
--- a/internal/api/handler/oss_handler_extra_test.go
+++ b/internal/api/handler/oss_handler_extra_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
@@ -107,7 +109,7 @@ func (s *stubOssVersionRepo) Update(ctx context.Context, v *model.OssVersion) er
 
 // --- tests ---
 func TestToOssComponent_AllFields(t *testing.T) {
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	hp := "http://hp"
 	repo := "http://repo"
 	desc := "d"
@@ -131,7 +133,7 @@ func TestToOssComponent_AllFields(t *testing.T) {
 }
 
 func TestToOssVersion_AllFields(t *testing.T) {
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	rel := now
 	licRaw := "MIT"
 	licConc := "MIT"
@@ -192,7 +194,7 @@ func TestCreateOssComponent(t *testing.T) {
 
 func TestListOssVersions(t *testing.T) {
 	ossID := uuid.NewString()
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	repo := &stubOssVersionRepo{searchFn: func(ctx context.Context, f domrepo.OssVersionFilter) ([]model.OssVersion, int, error) {
 		require.Equal(t, ossID, f.OssID)
 		return []model.OssVersion{{ID: uuid.NewString(), OssID: ossID, Version: "1", ReviewStatus: "draft", ScopeStatus: "IN_SCOPE", CreatedAt: now, UpdatedAt: now}}, 1, nil
@@ -237,7 +239,7 @@ func TestCreateOssVersion_WithOptions(t *testing.T) {
 	}}
 	h := &Handler{OssVersionRepo: repo}
 	e := setupEcho(h)
-	now := time.Now().UTC().Truncate(time.Second)
+	now := dbtime.DBTime{Time: time.Now().UTC().Truncate(time.Second)}
 	body := `{"version":"1.0.0","releaseDate":"` + now.Format("2006-01-02") + `","purl":"pkg:","cpeList":["c"],"modified":true,"supplierType":"ORIGIN"}`
 	req := httptest.NewRequest(http.MethodPost, "/oss/"+ossID+"/versions", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -308,7 +310,7 @@ func TestOssComponentStubMethods(t *testing.T) {
 func TestUpdateOssVersion(t *testing.T) {
 	ossID := uuid.NewString()
 	vid := uuid.NewString()
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	existing := model.OssVersion{ID: vid, OssID: ossID, Version: "1", ReviewStatus: "draft", ScopeStatus: "IN_SCOPE", CreatedAt: now, UpdatedAt: now}
 	var updated *model.OssVersion
 	repo := &stubOssVersionRepo{getFn: func(ctx context.Context, id string) (*model.OssVersion, error) {
@@ -331,7 +333,7 @@ func TestUpdateOssVersion(t *testing.T) {
 func TestUpdateOssVersion_WithFields(t *testing.T) {
 	ossID := uuid.NewString()
 	vid := uuid.NewString()
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	existing := model.OssVersion{ID: vid, OssID: ossID, Version: "1", ReviewStatus: "draft", ScopeStatus: "IN_SCOPE", CreatedAt: now, UpdatedAt: now}
 	var updated *model.OssVersion
 	repo := &stubOssVersionRepo{getFn: func(ctx context.Context, id string) (*model.OssVersion, error) {

--- a/internal/api/handler/scope_policy_handler.go
+++ b/internal/api/handler/scope_policy_handler.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
@@ -22,7 +24,7 @@ func toScopePolicy(m model.ScopePolicy) gen.ScopePolicy {
 		RuntimeRequiredDefaultInScope: &m.RuntimeRequiredDefaultInScope,
 		ServerEnvIncluded:             &m.ServerEnvIncluded,
 		AutoMarkForksInScope:          &m.AutoMarkForksInScope,
-		UpdatedAt:                     &m.UpdatedAt,
+		UpdatedAt:                     func() *time.Time { t := m.UpdatedAt.TimeValue(); return &t }(),
 		UpdatedBy:                     &m.UpdatedBy,
 	}
 }
@@ -54,7 +56,7 @@ func (h *Handler) UpdateScopePolicy(ctx echo.Context) error {
 		return err
 	}
 
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	var p *model.ScopePolicy
 	if existing != nil {
 		p = existing

--- a/internal/api/handler/users_handler.go
+++ b/internal/api/handler/users_handler.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -21,8 +23,8 @@ func toUser(m model.User) gen.User {
 		Id:        uid,
 		Username:  m.Username,
 		Active:    m.Active,
-		CreatedAt: m.CreatedAt,
-		UpdatedAt: m.UpdatedAt,
+		CreatedAt: m.CreatedAt.TimeValue(),
+		UpdatedAt: m.UpdatedAt.TimeValue(),
 	}
 	if m.DisplayName != nil {
 		res.DisplayName = m.DisplayName
@@ -78,7 +80,7 @@ func (h *Handler) CreateUser(ctx echo.Context) error {
 	if err := ctx.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid body")
 	}
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	id := uuid.NewString()
 	active := true
 	if req.Active != nil {
@@ -160,7 +162,7 @@ func (h *Handler) UpdateUser(ctx echo.Context, userId openapi_types.UUID) error 
 	if req.Active != nil {
 		u.Active = *req.Active
 	}
-	u.UpdatedAt = time.Now()
+	u.UpdatedAt = dbtime.DBTime{Time: time.Now()}
 	if err := h.UserRepo.Update(ctx.Request().Context(), u); err != nil {
 		return err
 	}

--- a/internal/domain/model/audit_log.go
+++ b/internal/domain/model/audit_log.go
@@ -1,6 +1,6 @@
 package model
 
-import "time"
+import "github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 // AuditLog は監査ログの 1 レコードを表す。
 type AuditLog struct {
@@ -10,5 +10,5 @@ type AuditLog struct {
 	Action     string
 	UserName   string
 	Summary    *string
-	CreatedAt  time.Time
+	CreatedAt  dbtime.DBTime
 }

--- a/internal/domain/model/oss_component.go
+++ b/internal/domain/model/oss_component.go
@@ -1,6 +1,6 @@
 package model
 
-import "time"
+import "github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 // OssComponent は OSS コンポーネントを表すドメインモデル。
 type OssComponent struct {
@@ -14,8 +14,8 @@ type OssComponent struct {
 	Layers           []string
 	DefaultUsageRole *string
 	Deprecated       bool
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	CreatedAt        dbtime.DBTime
+	UpdatedAt        dbtime.DBTime
 	Tags             []Tag
 }
 
@@ -23,5 +23,5 @@ type OssComponent struct {
 type Tag struct {
 	ID        string
 	Name      string
-	CreatedAt *time.Time
+	CreatedAt *dbtime.DBTime
 }

--- a/internal/domain/model/oss_version.go
+++ b/internal/domain/model/oss_version.go
@@ -1,13 +1,13 @@
 package model
 
-import "time"
+import "github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 // OssVersion は OSS コンポーネントのバージョン情報を表す。
 type OssVersion struct {
 	ID                      string
 	OssID                   string
 	Version                 string
-	ReleaseDate             *time.Time
+	ReleaseDate             *dbtime.DBTime
 	LicenseExpressionRaw    *string
 	LicenseConcluded        *string
 	Purl                    *string
@@ -16,10 +16,10 @@ type OssVersion struct {
 	Modified                bool
 	ModificationDescription *string
 	ReviewStatus            string
-	LastReviewedAt          *time.Time
+	LastReviewedAt          *dbtime.DBTime
 	ScopeStatus             string
 	SupplierType            *string
 	ForkOriginURL           *string
-	CreatedAt               time.Time
-	UpdatedAt               time.Time
+	CreatedAt               dbtime.DBTime
+	UpdatedAt               dbtime.DBTime
 }

--- a/internal/domain/model/project.go
+++ b/internal/domain/model/project.go
@@ -1,6 +1,6 @@
 package model
 
-import "time"
+import "github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 // Project はデリバリーユニットのプロジェクトを表すモデル。
 type Project struct {
@@ -9,9 +9,9 @@ type Project struct {
 	Name          string
 	Department    *string
 	Manager       *string
-	DeliveryDate  *time.Time
+	DeliveryDate  *dbtime.DBTime
 	Description   *string
 	OssUsageCount int
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	CreatedAt     dbtime.DBTime
+	UpdatedAt     dbtime.DBTime
 }

--- a/internal/domain/model/project_usage.go
+++ b/internal/domain/model/project_usage.go
@@ -1,6 +1,6 @@
 package model
 
-import "time"
+import "github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 // ProjectUsage はプロジェクト内での OSS 利用状況を表す。
 type ProjectUsage struct {
@@ -12,8 +12,8 @@ type ProjectUsage struct {
 	ScopeStatus      string
 	InclusionNote    *string
 	DirectDependency bool
-	AddedAt          time.Time
-	EvaluatedAt      *time.Time
+	AddedAt          dbtime.DBTime
+	EvaluatedAt      *dbtime.DBTime
 	EvaluatedBy      *string
 }
 

--- a/internal/domain/model/scope_policy.go
+++ b/internal/domain/model/scope_policy.go
@@ -1,6 +1,6 @@
 package model
 
-import "time"
+import "github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 // ScopePolicy は自動スコープ判定のポリシーを表す。
 type ScopePolicy struct {
@@ -8,6 +8,6 @@ type ScopePolicy struct {
 	RuntimeRequiredDefaultInScope bool
 	ServerEnvIncluded             bool
 	AutoMarkForksInScope          bool
-	UpdatedAt                     time.Time
+	UpdatedAt                     dbtime.DBTime
 	UpdatedBy                     string
 }

--- a/internal/domain/model/user.go
+++ b/internal/domain/model/user.go
@@ -1,6 +1,6 @@
 package model
 
-import "time"
+import "github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 // User はシステム利用ユーザー情報を表すモデル。
 type User struct {
@@ -11,6 +11,6 @@ type User struct {
 	PasswordHash string
 	Roles        []string
 	Active       bool
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	CreatedAt    dbtime.DBTime
+	UpdatedAt    dbtime.DBTime
 }

--- a/internal/domain/repository/audit_log_repository.go
+++ b/internal/domain/repository/audit_log_repository.go
@@ -2,7 +2,8 @@ package repository
 
 import (
 	"context"
-	"time"
+
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 	"github.com/ramsesyok/oss-catalog/internal/domain/model"
 )
@@ -11,8 +12,8 @@ import (
 type AuditLogFilter struct {
 	EntityType *string
 	EntityID   *string
-	From       *time.Time
-	To         *time.Time
+	From       *dbtime.DBTime
+	To         *dbtime.DBTime
 }
 
 // AuditLogRepository は監査ログの永続化処理を定義する。

--- a/internal/domain/repository/project_usage_repository.go
+++ b/internal/domain/repository/project_usage_repository.go
@@ -2,7 +2,8 @@ package repository
 
 import (
 	"context"
-	"time"
+
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 	"github.com/ramsesyok/oss-catalog/internal/domain/model"
 )
@@ -23,5 +24,5 @@ type ProjectUsageRepository interface {
 	Create(ctx context.Context, u *model.ProjectUsage) error
 	Update(ctx context.Context, u *model.ProjectUsage) error
 	Delete(ctx context.Context, id string) error
-	UpdateScope(ctx context.Context, id string, scopeStatus string, inclusionNote *string, evaluatedAt time.Time, evaluatedBy *string) error
+	UpdateScope(ctx context.Context, id string, scopeStatus string, inclusionNote *string, evaluatedAt dbtime.DBTime, evaluatedBy *string) error
 }

--- a/internal/infra/migration/migration.go
+++ b/internal/infra/migration/migration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ramsesyok/oss-catalog/internal/infra/repository"
 	"github.com/ramsesyok/oss-catalog/migrations"
 	"github.com/ramsesyok/oss-catalog/pkg/auth"
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
 )
 
 // Apply runs all up migrations using golang-migrate. If the schema is already up to date,
@@ -79,7 +80,7 @@ func ensureAdminUser(db *sql.DB) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	u := &model.User{
 		ID:           uuid.NewString(),
 		Username:     "admin",

--- a/internal/infra/repository/audit_log_repository_test.go
+++ b/internal/infra/repository/audit_log_repository_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -25,7 +27,7 @@ func TestAuditLogRepository_Search(t *testing.T) {
 	f := domrepo.AuditLogFilter{EntityType: func() *string { s := "PROJECT"; return &s }()}
 
 	query := regexp.QuoteMeta("SELECT id, entity_type, entity_id, action, user_name, summary, created_at FROM audit_logs WHERE entity_type = ? ORDER BY created_at DESC")
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	rows := sqlmock.NewRows([]string{"id", "entity_type", "entity_id", "action", "user_name", "summary", "created_at"}).
 		AddRow(uuid.NewString(), "PROJECT", "1", "CREATE", "user", "created", now)
 	mock.ExpectQuery(query).WithArgs("PROJECT").WillReturnRows(rows)
@@ -45,8 +47,8 @@ func TestAuditLogRepository_Search_AllFilters(t *testing.T) {
 
 	et := "PROJECT"
 	eid := "1"
-	from := time.Now().Add(-time.Hour)
-	to := time.Now()
+	from := dbtime.DBTime{Time: time.Now().Add(-time.Hour)}
+	to := dbtime.DBTime{Time: time.Now()}
 	f := domrepo.AuditLogFilter{EntityType: &et, EntityID: &eid, From: &from, To: &to}
 
 	query := regexp.QuoteMeta("SELECT id, entity_type, entity_id, action, user_name, summary, created_at FROM audit_logs WHERE entity_type = ? AND entity_id = ? AND created_at >= ? AND created_at <= ? ORDER BY created_at DESC")
@@ -89,7 +91,7 @@ func TestAuditLogRepository_Create(t *testing.T) {
 		EntityID:   "1",
 		Action:     "CREATE",
 		UserName:   "user",
-		CreatedAt:  time.Now(),
+		CreatedAt:  dbtime.DBTime{Time: time.Now()},
 	}
 
 	query := regexp.QuoteMeta("INSERT INTO audit_logs (id, entity_type, entity_id, action, user_name, summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)")

--- a/internal/infra/repository/oss_component_repository_test.go
+++ b/internal/infra/repository/oss_component_repository_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -27,7 +29,7 @@ func TestOssComponentRepository_Search(t *testing.T) {
 	mock.ExpectQuery(countQuery).WithArgs("%redis%").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
 	listQuery := regexp.QuoteMeta("SELECT oc.id, oc.name, oc.normalized_name, oc.homepage_url, oc.repository_url, oc.description, oc.primary_language, oc.default_usage_role, oc.deprecated, oc.created_at, oc.updated_at FROM oss_components oc WHERE normalized_name LIKE ? ORDER BY oc.created_at DESC LIMIT ? OFFSET ?")
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	mock.ExpectQuery(listQuery).WithArgs("%redis%", 10, 0).WillReturnRows(sqlmock.NewRows([]string{"id", "name", "normalized_name", "homepage_url", "repository_url", "description", "primary_language", "default_usage_role", "deprecated", "created_at", "updated_at"}).AddRow(uuid.NewString(), "Redis", "redis", nil, nil, nil, nil, nil, false, now, now))
 
 	res, total, err := repo.Search(context.Background(), f)
@@ -49,8 +51,8 @@ func TestOssComponentRepository_Create(t *testing.T) {
 		Name:           "Redis",
 		NormalizedName: "redis",
 		Deprecated:     false,
-		CreatedAt:      time.Now(),
-		UpdatedAt:      time.Now(),
+		CreatedAt:      dbtime.DBTime{Time: time.Now()},
+		UpdatedAt:      dbtime.DBTime{Time: time.Now()},
 	}
 
 	query := regexp.QuoteMeta("INSERT INTO oss_components (id, name, normalized_name, homepage_url, repository_url, description, primary_language, default_usage_role, deprecated, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")

--- a/internal/infra/repository/oss_component_tag_repository.go
+++ b/internal/infra/repository/oss_component_tag_repository.go
@@ -3,7 +3,8 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"time"
+
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 	"github.com/ramsesyok/oss-catalog/internal/domain/model"
 	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
@@ -30,7 +31,7 @@ func (r *OssComponentTagRepository) ListByOssID(ctx context.Context, ossID strin
 	var tags []model.Tag
 	for rows.Next() {
 		var t model.Tag
-		var created time.Time
+		var created dbtime.DBTime
 		if err := rows.Scan(&t.ID, &t.Name, &created); err != nil {
 			return nil, err
 		}

--- a/internal/infra/repository/oss_component_tag_repository_test.go
+++ b/internal/infra/repository/oss_component_tag_repository_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -21,7 +23,7 @@ func TestOssComponentTagRepository_ListByOssID(t *testing.T) {
 
 	ossID := uuid.NewString()
 	query := regexp.QuoteMeta(`SELECT tg.id, tg.name, tg.created_at FROM tags tg JOIN oss_component_tags ct ON ct.tag_id = tg.id WHERE ct.oss_id = ? ORDER BY tg.created_at DESC`)
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	rows := sqlmock.NewRows([]string{"id", "name", "created_at"}).AddRow(uuid.NewString(), "db", now)
 	mock.ExpectQuery(query).WithArgs(ossID).WillReturnRows(rows)
 

--- a/internal/infra/repository/oss_version_repository_test.go
+++ b/internal/infra/repository/oss_version_repository_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -28,7 +30,7 @@ func TestOssVersionRepository_Search(t *testing.T) {
 	mock.ExpectQuery(countQuery).WithArgs(f.OssID).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
 	listQuery := regexp.QuoteMeta("SELECT id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at FROM oss_versions WHERE oss_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?")
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	rows := sqlmock.NewRows([]string{"id", "oss_id", "version", "release_date", "license_expression_raw", "license_concluded", "purl", "cpe_list", "hash_sha256", "modified", "modification_description", "review_status", "last_reviewed_at", "scope_status", "supplier_type", "fork_origin_url", "created_at", "updated_at"}).
 		AddRow(uuid.NewString(), f.OssID, "1.0.0", now, nil, nil, nil, pq.StringArray{"cpe:/a"}, nil, false, nil, "draft", nil, "IN_SCOPE", nil, nil, now, now)
 	mock.ExpectQuery(listQuery).WithArgs(f.OssID, 10, 0).WillReturnRows(rows)
@@ -54,8 +56,8 @@ func TestOssVersionRepository_Create(t *testing.T) {
 		Modified:     false,
 		ReviewStatus: "draft",
 		ScopeStatus:  "IN_SCOPE",
-		CreatedAt:    time.Now(),
-		UpdatedAt:    time.Now(),
+		CreatedAt:    dbtime.DBTime{Time: time.Now()},
+		UpdatedAt:    dbtime.DBTime{Time: time.Now()},
 	}
 
 	query := regexp.QuoteMeta("INSERT INTO oss_versions (id, oss_id, version, release_date, license_expression_raw, license_concluded, purl, cpe_list, hash_sha256, modified, modification_description, review_status, last_reviewed_at, scope_status, supplier_type, fork_origin_url, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
@@ -77,11 +79,11 @@ func TestOssVersionRepository_Update(t *testing.T) {
 
 	v := &model.OssVersion{
 		ID:           uuid.NewString(),
-		ReleaseDate:  func() *time.Time { t := time.Now(); return &t }(),
+		ReleaseDate:  func() *dbtime.DBTime { t := dbtime.DBTime{Time: time.Now()}; return &t }(),
 		Modified:     true,
 		ReviewStatus: "verified",
 		ScopeStatus:  "IN_SCOPE",
-		UpdatedAt:    time.Now(),
+		UpdatedAt:    dbtime.DBTime{Time: time.Now()},
 	}
 
 	query := regexp.QuoteMeta("UPDATE oss_versions SET release_date = ?, license_expression_raw = ?, license_concluded = ?, purl = ?, cpe_list = ?, hash_sha256 = ?, modified = ?, modification_description = ?, review_status = ?, last_reviewed_at = ?, scope_status = ?, supplier_type = ?, fork_origin_url = ?, updated_at = ? WHERE id = ?")

--- a/internal/infra/repository/project_repository_test.go
+++ b/internal/infra/repository/project_repository_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -27,7 +29,7 @@ func TestProjectRepository_Search(t *testing.T) {
 	mock.ExpectQuery(countQuery).WithArgs("%PRJ%").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
 	listQuery := regexp.QuoteMeta("SELECT id, project_code, name, department, manager, delivery_date, description, created_at, updated_at, (SELECT COUNT(*) FROM project_usages u WHERE u.project_id = projects.id) FROM projects WHERE project_code LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?")
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	rows := sqlmock.NewRows([]string{"id", "project_code", "name", "department", "manager", "delivery_date", "description", "created_at", "updated_at", "count"}).
 		AddRow(uuid.NewString(), "PRJ-1", "Proj", nil, nil, nil, nil, now, now, 0)
 	mock.ExpectQuery(listQuery).WithArgs("%PRJ%", 10, 0).WillReturnRows(rows)
@@ -48,7 +50,7 @@ func TestProjectRepository_Get(t *testing.T) {
 
 	id := uuid.NewString()
 	query := regexp.QuoteMeta("SELECT id, project_code, name, department, manager, delivery_date, description, created_at, updated_at, (SELECT COUNT(*) FROM project_usages u WHERE u.project_id = projects.id) FROM projects WHERE id = ?")
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	mock.ExpectQuery(query).WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"id", "project_code", "name", "department", "manager", "delivery_date", "description", "created_at", "updated_at", "count"}).
 		AddRow(id, "PRJ-1", "Proj", nil, nil, nil, nil, now, now, 0))
 
@@ -65,7 +67,7 @@ func TestProjectRepository_Create(t *testing.T) {
 
 	repo := &ProjectRepository{DB: db}
 
-	p := &model.Project{ID: uuid.NewString(), ProjectCode: "PRJ-1", Name: "Proj", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	p := &model.Project{ID: uuid.NewString(), ProjectCode: "PRJ-1", Name: "Proj", CreatedAt: dbtime.DBTime{Time: time.Now()}, UpdatedAt: dbtime.DBTime{Time: time.Now()}}
 
 	query := regexp.QuoteMeta("INSERT INTO projects (id, project_code, name, department, manager, delivery_date, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
 	mock.ExpectExec(query).WithArgs(p.ID, p.ProjectCode, p.Name, p.Department, p.Manager, p.DeliveryDate, p.Description, p.CreatedAt, p.UpdatedAt).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -82,7 +84,7 @@ func TestProjectRepository_Update(t *testing.T) {
 
 	repo := &ProjectRepository{DB: db}
 
-	p := &model.Project{ID: uuid.NewString(), Name: "Proj", UpdatedAt: time.Now()}
+	p := &model.Project{ID: uuid.NewString(), Name: "Proj", UpdatedAt: dbtime.DBTime{Time: time.Now()}}
 
 	query := regexp.QuoteMeta("UPDATE projects SET name = ?, department = ?, manager = ?, delivery_date = ?, description = ?, updated_at = ? WHERE id = ?")
 	mock.ExpectExec(query).WithArgs(p.Name, p.Department, p.Manager, p.DeliveryDate, p.Description, p.UpdatedAt, p.ID).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/internal/infra/repository/project_usage_repository.go
+++ b/internal/infra/repository/project_usage_repository.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
+
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 	"github.com/ramsesyok/oss-catalog/internal/domain/model"
 	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
@@ -89,7 +90,7 @@ func (r *ProjectUsageRepository) Delete(ctx context.Context, id string) error {
 }
 
 // UpdateScope はスコープ関連のフィールドのみ更新する。
-func (r *ProjectUsageRepository) UpdateScope(ctx context.Context, id string, scopeStatus string, inclusionNote *string, evaluatedAt time.Time, evaluatedBy *string) error {
+func (r *ProjectUsageRepository) UpdateScope(ctx context.Context, id string, scopeStatus string, inclusionNote *string, evaluatedAt dbtime.DBTime, evaluatedBy *string) error {
 	query := `UPDATE project_usages SET scope_status = ?, inclusion_note = ?, evaluated_at = ?, evaluated_by = ? WHERE id = ?`
 	_, err := r.DB.ExecContext(ctx, query, scopeStatus, inclusionNote, evaluatedAt, evaluatedBy, id)
 	return err

--- a/internal/infra/repository/scope_policy_repository_test.go
+++ b/internal/infra/repository/scope_policy_repository_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -21,7 +23,7 @@ func TestScopePolicyRepository_Get(t *testing.T) {
 	repo := &ScopePolicyRepository{DB: db}
 
 	query := regexp.QuoteMeta(`SELECT id, runtime_required_default_in_scope, server_env_included, auto_mark_forks_in_scope, updated_at, updated_by FROM scope_policies LIMIT 1`)
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	rows := sqlmock.NewRows([]string{"id", "runtime_required_default_in_scope", "server_env_included", "auto_mark_forks_in_scope", "updated_at", "updated_by"}).
 		AddRow(uuid.NewString(), true, false, true, now, "user")
 	mock.ExpectQuery(query).WillReturnRows(rows)
@@ -59,7 +61,7 @@ func TestScopePolicyRepository_Update(t *testing.T) {
 		RuntimeRequiredDefaultInScope: true,
 		ServerEnvIncluded:             false,
 		AutoMarkForksInScope:          true,
-		UpdatedAt:                     time.Now(),
+		UpdatedAt:                     dbtime.DBTime{Time: time.Now()},
 		UpdatedBy:                     "user",
 	}
 

--- a/internal/infra/repository/sqlhelper.go
+++ b/internal/infra/repository/sqlhelper.go
@@ -3,7 +3,8 @@ package repository
 import (
 	"database/sql"
 	"strings"
-	"time"
+
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
 )
 
 // whereClause は条件句の配列から WHERE 句文字列を生成する。
@@ -23,9 +24,10 @@ func strPtr(ns sql.NullString) *string {
 }
 
 // timePtr は NullTime から *time.Time を生成する。
-func timePtr(nt sql.NullTime) *time.Time {
+func timePtr(nt sql.NullTime) *dbtime.DBTime {
 	if nt.Valid {
-		return &nt.Time
+		t := dbtime.DBTime{Time: nt.Time}
+		return &t
 	}
 	return nil
 }

--- a/internal/infra/repository/sqlite_integration_test.go
+++ b/internal/infra/repository/sqlite_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -40,7 +42,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		defer db.Close()
 
 		repo := &TagRepository{DB: db}
-		now := time.Now()
+		now := dbtime.DBTime{Time: time.Now()}
 		tag := &model.Tag{ID: uuid.NewString(), Name: "db", CreatedAt: &now}
 		require.NoError(t, repo.Create(ctx, tag))
 		tags, err := repo.List(ctx)
@@ -61,7 +63,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		tagRepo := &TagRepository{DB: db}
 		compTagRepo := &OssComponentTagRepository{DB: db}
 
-		now := time.Now()
+		now := dbtime.DBTime{Time: time.Now()}
 		tag := &model.Tag{ID: uuid.NewString(), Name: "db", CreatedAt: &now}
 		require.NoError(t, tagRepo.Create(ctx, tag))
 
@@ -106,7 +108,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		compRepo := &OssComponentRepository{DB: db}
 		verRepo := &OssVersionRepository{DB: db}
 
-		now := time.Now()
+		now := dbtime.DBTime{Time: time.Now()}
 		comp := &model.OssComponent{ID: uuid.NewString(), Name: "Redis", NormalizedName: "redis", CreatedAt: now, UpdatedAt: now}
 		require.NoError(t, compRepo.Create(ctx, comp))
 
@@ -126,7 +128,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		require.Equal(t, ver.ID, got.ID)
 
 		ver.ReviewStatus = "verified"
-		ver.UpdatedAt = time.Now()
+		ver.UpdatedAt = dbtime.DBTime{Time: time.Now()}
 		require.NoError(t, verRepo.Update(ctx, ver))
 
 		res, total, err := verRepo.Search(ctx, domrepo.OssVersionFilter{OssID: comp.ID, ReviewStatus: "verified", Page: 1, Size: 10})
@@ -145,7 +147,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		defer db.Close()
 		repo := &ProjectRepository{DB: db}
 
-		now := time.Now()
+		now := dbtime.DBTime{Time: time.Now()}
 		proj := &model.Project{ID: uuid.NewString(), ProjectCode: "P1", Name: "Proj", CreatedAt: now, UpdatedAt: now}
 		require.NoError(t, repo.Create(ctx, proj))
 
@@ -154,7 +156,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		require.Equal(t, proj.ID, p.ID)
 
 		proj.Name = "Updated"
-		proj.UpdatedAt = time.Now()
+		proj.UpdatedAt = dbtime.DBTime{Time: time.Now()}
 		require.NoError(t, repo.Update(ctx, proj))
 
 		res, total, err := repo.Search(ctx, domrepo.ProjectFilter{Name: "Upd", Page: 1, Size: 10})
@@ -173,7 +175,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		projRepo := &ProjectRepository{DB: db}
 		usageRepo := &ProjectUsageRepository{DB: db}
 
-		now := time.Now()
+		now := dbtime.DBTime{Time: time.Now()}
 		comp := &model.OssComponent{ID: uuid.NewString(), Name: "Redis", NormalizedName: "redis", CreatedAt: now, UpdatedAt: now}
 		require.NoError(t, compRepo.Create(ctx, comp))
 		ver := &model.OssVersion{ID: uuid.NewString(), OssID: comp.ID, Version: "1.0.0", ReviewStatus: "draft", ScopeStatus: "IN_SCOPE", CreatedAt: now, UpdatedAt: now}
@@ -202,7 +204,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		require.NoError(t, usageRepo.Update(ctx, usage))
 
 		note := "out"
-		now2 := time.Now()
+		now2 := dbtime.DBTime{Time: time.Now()}
 		user := "tester"
 		require.NoError(t, usageRepo.UpdateScope(ctx, usage.ID, "OUT_SCOPE", &note, now2, &user))
 
@@ -213,7 +215,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		db := setupSQLiteDB(t)
 		defer db.Close()
 		repo := &ScopePolicyRepository{DB: db}
-		now := time.Now()
+		now := dbtime.DBTime{Time: time.Now()}
 		policy := &model.ScopePolicy{ID: uuid.NewString(), RuntimeRequiredDefaultInScope: true, ServerEnvIncluded: false, AutoMarkForksInScope: true, UpdatedAt: now, UpdatedBy: "user"}
 		require.NoError(t, repo.Update(ctx, policy))
 		p, err := repo.Get(ctx)
@@ -225,7 +227,7 @@ func TestRepositories_SQLite(t *testing.T) {
 		db := setupSQLiteDB(t)
 		defer db.Close()
 		repo := &AuditLogRepository{DB: db}
-		now := time.Now()
+		now := dbtime.DBTime{Time: time.Now()}
 		l := &model.AuditLog{ID: uuid.NewString(), EntityType: "PROJECT", EntityID: "1", Action: "CREATE", UserName: "user", CreatedAt: now}
 		require.NoError(t, repo.Create(ctx, l))
 		et := "PROJECT"

--- a/internal/infra/repository/tag_repository.go
+++ b/internal/infra/repository/tag_repository.go
@@ -3,7 +3,8 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"time"
+
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
 
 	"github.com/ramsesyok/oss-catalog/internal/domain/model"
 	domrepo "github.com/ramsesyok/oss-catalog/internal/domain/repository"
@@ -27,7 +28,7 @@ func (r *TagRepository) List(ctx context.Context) ([]model.Tag, error) {
 	var tags []model.Tag
 	for rows.Next() {
 		var t model.Tag
-		var created time.Time
+		var created dbtime.DBTime
 		if err := rows.Scan(&t.ID, &t.Name, &created); err != nil {
 			return nil, err
 		}

--- a/internal/infra/repository/tag_repository_test.go
+++ b/internal/infra/repository/tag_repository_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -22,7 +24,7 @@ func TestTagRepository_List(t *testing.T) {
 	repo := &TagRepository{DB: db}
 
 	query := regexp.QuoteMeta(`SELECT id, name, created_at FROM tags ORDER BY created_at DESC`)
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	rows := sqlmock.NewRows([]string{"id", "name", "created_at"}).
 		AddRow(uuid.NewString(), "db", now)
 	mock.ExpectQuery(query).WillReturnRows(rows)
@@ -55,7 +57,7 @@ func TestTagRepository_Create(t *testing.T) {
 
 	repo := &TagRepository{DB: db}
 
-	t1 := &model.Tag{ID: uuid.NewString(), Name: "db", CreatedAt: func() *time.Time { v := time.Now(); return &v }()}
+	t1 := &model.Tag{ID: uuid.NewString(), Name: "db", CreatedAt: func() *dbtime.DBTime { v := dbtime.DBTime{Time: time.Now()}; return &v }()}
 
 	query := regexp.QuoteMeta(`INSERT INTO tags (id, name, created_at) VALUES (?, ?, ?)`)
 	mock.ExpectExec(query).WithArgs(t1.ID, t1.Name, t1.CreatedAt).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/internal/infra/repository/user_repository_test.go
+++ b/internal/infra/repository/user_repository_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ramsesyok/oss-catalog/pkg/dbtime"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -28,7 +30,7 @@ func TestUserRepository_Search(t *testing.T) {
 	mock.ExpectQuery(countQuery).WithArgs("%adm%").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
 	listQuery := regexp.QuoteMeta("SELECT id, username, display_name, email, password_hash, roles, active, created_at, updated_at FROM users WHERE username LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?")
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	rows := sqlmock.NewRows([]string{"id", "username", "display_name", "email", "password_hash", "roles", "active", "created_at", "updated_at"}).
 		AddRow(uuid.NewString(), "admin", nil, nil, "hash", pq.StringArray{"ADMIN"}, true, now, now)
 	mock.ExpectQuery(listQuery).WithArgs("%adm%", 10, 0).WillReturnRows(rows)
@@ -49,7 +51,7 @@ func TestUserRepository_Get(t *testing.T) {
 
 	id := uuid.NewString()
 	query := regexp.QuoteMeta("SELECT id, username, display_name, email, password_hash, roles, active, created_at, updated_at FROM users WHERE id = ?")
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	mock.ExpectQuery(query).WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"id", "username", "display_name", "email", "password_hash", "roles", "active", "created_at", "updated_at"}).
 		AddRow(id, "admin", nil, nil, "hash", pq.StringArray{"ADMIN"}, true, now, now))
 
@@ -68,7 +70,7 @@ func TestUserRepository_FindByUsername(t *testing.T) {
 
 	username := "admin"
 	query := regexp.QuoteMeta("SELECT id, username, display_name, email, password_hash, roles, active, created_at, updated_at FROM users WHERE username = ?")
-	now := time.Now()
+	now := dbtime.DBTime{Time: time.Now()}
 	id := uuid.NewString()
 	mock.ExpectQuery(query).WithArgs(username).WillReturnRows(
 		sqlmock.NewRows([]string{"id", "username", "display_name", "email", "password_hash", "roles", "active", "created_at", "updated_at"}).
@@ -88,7 +90,7 @@ func TestUserRepository_Create(t *testing.T) {
 
 	repo := &UserRepository{DB: db}
 
-	u := &model.User{ID: uuid.NewString(), Username: "admin", Roles: []string{"ADMIN"}, Active: true, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	u := &model.User{ID: uuid.NewString(), Username: "admin", Roles: []string{"ADMIN"}, Active: true, CreatedAt: dbtime.DBTime{Time: time.Now()}, UpdatedAt: dbtime.DBTime{Time: time.Now()}}
 
 	query := regexp.QuoteMeta("INSERT INTO users (id, username, display_name, email, password_hash, roles, active, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
 	mock.ExpectExec(query).WithArgs(u.ID, u.Username, u.DisplayName, u.Email, u.PasswordHash, pq.Array(u.Roles), u.Active, u.CreatedAt, u.UpdatedAt).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -105,7 +107,7 @@ func TestUserRepository_Update(t *testing.T) {
 
 	repo := &UserRepository{DB: db}
 
-	u := &model.User{ID: uuid.NewString(), PasswordHash: "h", Roles: []string{"ADMIN"}, Active: true, UpdatedAt: time.Now()}
+	u := &model.User{ID: uuid.NewString(), PasswordHash: "h", Roles: []string{"ADMIN"}, Active: true, UpdatedAt: dbtime.DBTime{Time: time.Now()}}
 
 	query := regexp.QuoteMeta("UPDATE users SET display_name = ?, email = ?, password_hash = ?, roles = ?, active = ?, updated_at = ? WHERE id = ?")
 	mock.ExpectExec(query).WithArgs(u.DisplayName, u.Email, u.PasswordHash, pq.Array(u.Roles), u.Active, u.UpdatedAt, u.ID).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/dbtime/dbtime.go
+++ b/pkg/dbtime/dbtime.go
@@ -1,0 +1,48 @@
+package dbtime
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"time"
+)
+
+type DBTime struct{ time.Time }
+
+var timeLayouts = []string{
+	time.RFC3339Nano,
+	"2006-01-02 15:04:05.999999999Z",
+	"2006-01-02 15:04:05Z07:00",
+	"2006-01-02 15:04:05",
+}
+
+func (t *DBTime) Scan(v any) error {
+	switch x := v.(type) {
+	case time.Time:
+		t.Time = x.UTC()
+		return nil
+	case string:
+		for _, layout := range timeLayouts {
+			if ts, err := time.Parse(layout, x); err == nil {
+				t.Time = ts.UTC()
+				return nil
+			}
+		}
+		return fmt.Errorf("unsupported time string %q", x)
+	case []byte:
+		return t.Scan(string(x))
+	case int64:
+		t.Time = time.Unix(x, 0).UTC()
+		return nil
+	default:
+		return fmt.Errorf("unsupported type %T", v)
+	}
+}
+
+func (t DBTime) Value() (driver.Value, error) {
+	return t.Time.UTC(), nil
+}
+
+// Time returns time.Time value in UTC.
+func (t DBTime) TimeValue() time.Time {
+	return t.Time.UTC()
+}


### PR DESCRIPTION
## Summary
- add dbtime.DBTime implementing sql.Scanner and driver.Valuer
- replace time.Time fields in domain models with DBTime
- update repositories, handlers and tests to use DBTime
- normalize time conversion during migrations

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d5ff079208320b3e7656e29f18204