### PR TITLE
chore: suppress deprecated AST warnings in Tavern test

### DIFF
--- a/tests/test_oss.tavern.yaml
+++ b/tests/test_oss.tavern.yaml
@@ -1,5 +1,10 @@
 test_name: "list oss"
 
+# Suppress deprecation warnings from pytest's assertion rewriting
+marks:
+  - filterwarnings: "ignore:ast.Str is deprecated:DeprecationWarning"
+  - filterwarnings: "ignore:Attribute s is deprecated:DeprecationWarning"
+
 stages:
   - name: get list
     request:


### PR DESCRIPTION
## Summary
- silence ast.Str related deprecation warnings in Tavern API test

## Testing
- `go vet ./...`
- `go test ./...`
- `pytest tests/test_oss.tavern.yaml -q`


------
https://chatgpt.com/codex/tasks/task_e_688d8852cccc83209779be6f2ff61829