### PR TITLE
test: add user creation api tests

### DIFF
--- a/tests/test_users.tavern.yaml
+++ b/tests/test_users.tavern.yaml
@@ -1,0 +1,49 @@
+test_name: "create viewer user"
+
+stages:
+  - name: create viewer user
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: viewer1
+        roles: [VIEWER]
+        password: viewerpass
+    response:
+      status_code: 201
+      json:
+        id: !anystr
+        username: viewer1
+        roles: [VIEWER]
+        active: true
+        createdAt: !anystr
+        updatedAt: !anystr
+        email: null
+
+---
+
+test_name: "create editor user"
+
+stages:
+  - name: create editor user
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: editor1
+        roles: [EDITOR]
+        password: editorpass
+    response:
+      status_code: 201
+      json:
+        id: !anystr
+        username: editor1
+        roles: [EDITOR]
+        active: true
+        createdAt: !anystr
+        updatedAt: !anystr
+        email: null


### PR DESCRIPTION
## Summary
- add tavern tests for user creation API covering VIEWER and EDITOR roles

## Testing
- `go generate ./...`
- `go vet ./...`
- `go test ./...`
- `pytest -vv tests`


------
https://chatgpt.com/codex/tasks/task_e_688d8b7166008320b68f2a0d22de4e6b