### PR TITLE
test: add tavern tests for user retrieval

### DIFF
--- a/tests/test_users_get.tavern.yaml
+++ b/tests/test_users_get.tavern.yaml
@@ -1,0 +1,112 @@
+test_name: "get user success"
+
+stages:
+  - name: create user for get
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: get_user_success
+        roles: [EDITOR]
+        password: getpass
+    response:
+      status_code: 201
+      json:
+        id: !anystr
+        username: get_user_success
+        roles: [EDITOR]
+        active: true
+        createdAt: !anystr
+        updatedAt: !anystr
+        email: null
+      save:
+        json:
+          user_id: id
+
+  - name: get user by id
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users/{user_id}"
+      method: GET
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+    response:
+      status_code: 200
+      json:
+        id: "{user_id}"
+        username: get_user_success
+        roles: [EDITOR]
+        active: true
+        createdAt: !anystr
+        updatedAt: !anystr
+        email: null
+
+---
+
+test_name: "get user unauthorized"
+
+stages:
+  - name: request without token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users/00000000-0000-0000-0000-000000000000"
+      method: GET
+    response:
+      status_code: 401
+
+---
+
+test_name: "get user forbidden"
+
+stages:
+  - name: create viewer user
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: get_user_forbidden
+        roles: [VIEWER]
+        password: "$2a$10$Om2EuihRx7HkQQH6kGR92e6JrjZKoggTONqqITt4pmi84LmQg0oDO"
+    response:
+      status_code: 201
+      save:
+        json:
+          viewer_id: id
+
+  - name: login as viewer
+    request:
+      url: "{tavern.env_vars.BASE_URL}/auth/login"
+      method: POST
+      json:
+        username: get_user_forbidden
+        password: viewerpass
+    response:
+      status_code: 200
+      save:
+        json:
+          viewer_token: accessToken
+
+  - name: get user with viewer token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users/{viewer_id}"
+      method: GET
+      headers:
+        Authorization: "Bearer {viewer_token}"
+    response:
+      status_code: 403
+
+---
+
+test_name: "get user not found"
+
+stages:
+  - name: get non-existent user
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users/00000000-0000-0000-0000-000000000001"
+      method: GET
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+    response:
+      status_code: 404

--- a/tests/test_users_list.tavern.yaml
+++ b/tests/test_users_list.tavern.yaml
@@ -1,0 +1,99 @@
+test_name: "list users success"
+
+stages:
+  - name: create user for list
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: list_user_success
+        roles: [VIEWER]
+        password: listpass
+    response:
+      status_code: 201
+      json:
+        id: !anystr
+        username: list_user_success
+        roles: [VIEWER]
+        active: true
+        createdAt: !anystr
+        updatedAt: !anystr
+        email: null
+
+  - name: list users by username
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: GET
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      params:
+        username: list_user_success
+        size: 10
+    response:
+      status_code: 200
+      json:
+        items:
+          - id: !anystr
+            username: list_user_success
+            roles: [VIEWER]
+            active: true
+            createdAt: !anystr
+            updatedAt: !anystr
+            email: null
+        page: 1
+        size: 10
+        total: 1
+
+---
+
+test_name: "list users unauthorized"
+
+stages:
+  - name: request without token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: GET
+    response:
+      status_code: 401
+
+---
+
+test_name: "list users forbidden"
+
+stages:
+  - name: create viewer user
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: list_user_forbidden
+        roles: [VIEWER]
+        password: "$2a$10$Om2EuihRx7HkQQH6kGR92e6JrjZKoggTONqqITt4pmi84LmQg0oDO"
+    response:
+      status_code: 201
+
+  - name: login as viewer
+    request:
+      url: "{tavern.env_vars.BASE_URL}/auth/login"
+      method: POST
+      json:
+        username: list_user_forbidden
+        password: viewerpass
+    response:
+      status_code: 200
+      save:
+        json:
+          viewer_token: accessToken
+
+  - name: list users with viewer token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: GET
+      headers:
+        Authorization: "Bearer {viewer_token}"
+    response:
+      status_code: 403


### PR DESCRIPTION
## Summary
- add Tavern tests for listing users
- add Tavern tests for retrieving user details

## Testing
- `go generate ./...`
- `go vet ./...`
- `go test ./...`
- `pytest -vv tests`


------
https://chatgpt.com/codex/tasks/task_e_688d9e7e92bc8320a89777a4e4d0b740