### PR TITLE
Add Tavern tests for OSS create and list

### DIFF
--- a/tests/test_oss.tavern.yaml
+++ b/tests/test_oss.tavern.yaml
@@ -1,7 +1,28 @@
-test_name: "list oss"
+test_name: "create and list oss"
 
 stages:
-  - name: get list
+  - name: create oss
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        name: tavern-oss
+    response:
+      status_code: 201
+      strict: false
+      json:
+        id: !anystr
+        name: tavern-oss
+        deprecated: false
+        createdAt: !anystr
+        updatedAt: !anystr
+      save:
+        json:
+          oss_id: id
+
+  - name: list oss
     request:
       url: "{tavern.env_vars.BASE_URL}/oss"
       method: GET
@@ -9,8 +30,15 @@ stages:
         Authorization: "Bearer {tavern.env_vars.TOKEN}"
     response:
       status_code: 200
+      strict: false
       json:
         page: 1
         size: 50
-        total: 0
-        items: []
+        total: 1
+        items:
+          - id: "{oss_id}"
+            name: tavern-oss
+            deprecated: false
+            createdAt: !anystr
+            updatedAt: !anystr
+


### PR DESCRIPTION
## Summary
- cover creating an OSS component and listing via API

## Testing
- `go vet ./...`
- `go test ./...`
- `pytest -vv tests`


------
https://chatgpt.com/codex/tasks/task_e_688da2a880348320956f139b07dc292d