### PR TITLE
Add Tavern tests for OSS component endpoints

### DIFF
--- a/tests/test_oss_delete.tavern.yaml
+++ b/tests/test_oss_delete.tavern.yaml
@@ -1,0 +1,120 @@
+test_name: "delete oss component success"
+
+stages:
+  - name: create oss for delete
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        name: delete_target
+    response:
+      status_code: 201
+      json:
+        id: !anystr
+        name: delete_target
+        normalizedName: delete_target
+        homepageUrl: null
+        repositoryUrl: null
+        description: null
+        primaryLanguage: null
+        deprecated: false
+        createdAt: !anystr
+        updatedAt: !anystr
+      save:
+        json:
+          oss_id: id
+
+  - name: delete oss
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/{oss_id}"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+    response:
+      status_code: 200
+
+---
+
+test_name: "delete oss component forbidden"
+
+stages:
+  - name: create viewer user
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: delete_viewer
+        roles: [VIEWER]
+        password: "$2a$10$Om2EuihRx7HkQQH6kGR92e6JrjZKoggTONqqITt4pmi84LmQg0oDO"
+    response:
+      status_code: 201
+      save:
+        json:
+          viewer_id: id
+
+  - name: login as viewer
+    request:
+      url: "{tavern.env_vars.BASE_URL}/auth/login"
+      method: POST
+      json:
+        username: delete_viewer
+        password: viewerpass
+    response:
+      status_code: 200
+      save:
+        json:
+          viewer_token: accessToken
+
+  - name: create oss for forbidden delete
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        name: delete_forbidden
+    response:
+      status_code: 201
+      save:
+        json:
+          oss_id: id
+
+  - name: delete oss with viewer token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/{oss_id}"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {viewer_token}"
+    response:
+      status_code: 403
+
+---
+
+test_name: "delete oss component unauthorized"
+
+stages:
+  - name: delete without token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/00000000-0000-0000-0000-000000000000"
+      method: DELETE
+    response:
+      status_code: 401
+
+---
+
+test_name: "delete oss component not found"
+marks: [xfail]
+
+stages:
+  - name: delete non-existent oss
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/00000000-0000-0000-0000-000000000001"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+    response:
+      status_code: 404

--- a/tests/test_oss_get.tavern.yaml
+++ b/tests/test_oss_get.tavern.yaml
@@ -1,0 +1,63 @@
+test_name: "get oss component success"
+
+stages:
+  - name: create oss for get
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        name: get_oss_success
+    response:
+      status_code: 201
+      json:
+        id: !anystr
+        name: get_oss_success
+        normalizedName: get_oss_success
+        homepageUrl: null
+        repositoryUrl: null
+        description: null
+        primaryLanguage: null
+        deprecated: false
+        createdAt: !anystr
+        updatedAt: !anystr
+      save:
+        json:
+          oss_id: id
+
+  - name: get oss by id
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/{oss_id}"
+      method: GET
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+    response:
+      status_code: 200
+
+---
+
+test_name: "get oss component unauthorized"
+
+stages:
+  - name: request without token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/00000000-0000-0000-0000-000000000000"
+      method: GET
+    response:
+      status_code: 401
+
+---
+
+test_name: "get oss component not found"
+marks: [xfail]
+
+stages:
+  - name: get non-existent oss
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/00000000-0000-0000-0000-000000000001"
+      method: GET
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+    response:
+      status_code: 404

--- a/tests/test_oss_patch.tavern.yaml
+++ b/tests/test_oss_patch.tavern.yaml
@@ -1,0 +1,128 @@
+test_name: "update oss component success"
+
+stages:
+  - name: create oss for patch
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        name: patch_target
+    response:
+      status_code: 201
+      json:
+        id: !anystr
+        name: patch_target
+        normalizedName: patch_target
+        homepageUrl: null
+        repositoryUrl: null
+        description: null
+        primaryLanguage: null
+        deprecated: false
+        createdAt: !anystr
+        updatedAt: !anystr
+      save:
+        json:
+          oss_id: id
+
+  - name: patch oss
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/{oss_id}"
+      method: PATCH
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        description: patched description
+    response:
+      status_code: 200
+
+---
+
+test_name: "update oss component forbidden"
+
+stages:
+  - name: create viewer user
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: patch_viewer
+        roles: [VIEWER]
+        password: "$2a$10$Om2EuihRx7HkQQH6kGR92e6JrjZKoggTONqqITt4pmi84LmQg0oDO"
+    response:
+      status_code: 201
+      save:
+        json:
+          viewer_id: id
+
+  - name: login as viewer
+    request:
+      url: "{tavern.env_vars.BASE_URL}/auth/login"
+      method: POST
+      json:
+        username: patch_viewer
+        password: viewerpass
+    response:
+      status_code: 200
+      save:
+        json:
+          viewer_token: accessToken
+
+  - name: create oss for forbidden test
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        name: patch_forbidden
+    response:
+      status_code: 201
+      save:
+        json:
+          oss_id: id
+
+  - name: patch oss with viewer token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/{oss_id}"
+      method: PATCH
+      headers:
+        Authorization: "Bearer {viewer_token}"
+      json:
+        description: no effect
+    response:
+      status_code: 403
+
+---
+
+test_name: "update oss component unauthorized"
+
+stages:
+  - name: patch without token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/00000000-0000-0000-0000-000000000000"
+      method: PATCH
+      json:
+        description: x
+    response:
+      status_code: 401
+
+---
+
+test_name: "update oss component not found"
+marks: [xfail]
+
+stages:
+  - name: patch non-existent oss
+    request:
+      url: "{tavern.env_vars.BASE_URL}/oss/00000000-0000-0000-0000-000000000001"
+      method: PATCH
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        description: x
+    response:
+      status_code: 404


### PR DESCRIPTION
## Summary
- add API tests for retrieving, patching, and deleting OSS components
- cover unauthorized and forbidden access cases; mark not-found cases as expected failures pending endpoint implementation

## Testing
- `go generate ./...`
- `go vet ./...`
- `go test ./...`
- `pytest -vv tests`


------
https://chatgpt.com/codex/tasks/task_e_688dacfaa17883208aa53b0422a853c4