### PR TITLE
test: cover scope policy API

### DIFF
--- a/tests/test_scope_policy.tavern.yaml
+++ b/tests/test_scope_policy.tavern.yaml
@@ -1,0 +1,149 @@
+test_name: "patch and get scope policy"
+
+stages:
+  - name: update scope policy as admin
+    request:
+      url: "{tavern.env_vars.BASE_URL}/scope/policy"
+      method: PATCH
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        runtimeRequiredDefaultInScope: true
+        serverEnvIncluded: false
+        autoMarkForksInScope: true
+    response:
+      status_code: 200
+      strict: false
+      json:
+        id: !anystr
+        runtimeRequiredDefaultInScope: true
+        serverEnvIncluded: false
+        autoMarkForksInScope: true
+        updatedAt: !anystr
+      save:
+        json:
+          policy_id: id
+
+  - name: get scope policy as admin
+    request:
+      url: "{tavern.env_vars.BASE_URL}/scope/policy"
+      method: GET
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+    response:
+      status_code: 200
+      strict: false
+      json:
+        id: "{policy_id}"
+        runtimeRequiredDefaultInScope: true
+        serverEnvIncluded: false
+        autoMarkForksInScope: true
+        updatedAt: !anystr
+
+---
+
+test_name: "get scope policy unauthorized"
+
+stages:
+  - name: get policy without token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/scope/policy"
+      method: GET
+    response:
+      status_code: 401
+
+---
+
+test_name: "patch scope policy unauthorized"
+
+stages:
+  - name: patch policy without token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/scope/policy"
+      method: PATCH
+      json:
+        runtimeRequiredDefaultInScope: false
+    response:
+      status_code: 401
+
+---
+
+test_name: "patch scope policy forbidden for viewer"
+
+stages:
+  - name: create viewer user for policy
+    request:
+      url: "{tavern.env_vars.BASE_URL}/users"
+      method: POST
+      headers:
+        Authorization: "Bearer {tavern.env_vars.TOKEN}"
+      json:
+        username: viewer_policy
+        roles: [VIEWER]
+        password: '$2a$10$Om2EuihRx7HkQQH6kGR92e6JrjZKoggTONqqITt4pmi84LmQg0oDO'
+    response:
+      status_code: 201
+      strict: false
+      json:
+        id: !anystr
+      save:
+        json:
+          viewer_id: id
+
+  - name: login viewer
+    request:
+      url: "{tavern.env_vars.BASE_URL}/auth/login"
+      method: POST
+      json:
+        username: viewer_policy
+        password: viewerpass
+    response:
+      status_code: 200
+      save:
+        json:
+          viewer_token: accessToken
+
+  - name: patch policy with viewer token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/scope/policy"
+      method: PATCH
+      headers:
+        Authorization: "Bearer {viewer_token}"
+      json:
+        serverEnvIncluded: true
+    response:
+      status_code: 403
+
+---
+
+test_name: "get scope policy with viewer"
+
+stages:
+  - name: login viewer for get
+    request:
+      url: "{tavern.env_vars.BASE_URL}/auth/login"
+      method: POST
+      json:
+        username: viewer_policy
+        password: viewerpass
+    response:
+      status_code: 200
+      save:
+        json:
+          viewer_token: accessToken
+
+  - name: get policy with viewer token
+    request:
+      url: "{tavern.env_vars.BASE_URL}/scope/policy"
+      method: GET
+      headers:
+        Authorization: "Bearer {viewer_token}"
+    response:
+      status_code: 200
+      strict: false
+      json:
+        id: !anystr
+        runtimeRequiredDefaultInScope: true
+        serverEnvIncluded: false
+        autoMarkForksInScope: true
+        updatedAt: !anystr


### PR DESCRIPTION
## Summary
- add Tavern tests for scope policy endpoints covering success, unauthorized, and role-restricted cases

## Testing
- `go generate ./...`
- `go vet ./...`
- `go test ./...`
- `pytest -vv tests`


------
https://chatgpt.com/codex/tasks/task_e_688dcedf797c8320964cc2e52d7212d4